### PR TITLE
Add `updatedAt` to API schema

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -197,6 +197,7 @@ components:
         - uid
         - status
         - registrationDate
+        - updatedAt
       properties:
         uid:
           type: string
@@ -211,6 +212,9 @@ components:
           type: string
           format: date
           nullable: true
+        updatedAt:
+          type: string
+          format: date
       additionalProperties: false
     InitialLpa:
       type: object


### PR DESCRIPTION
Expose the `updatedAt` field to provide an identifier of the version of the LPA you're looking at

#patch