### PR TITLE
Require breakglass for preprod/prod access

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -42,6 +42,7 @@ jobs:
     with:
       workspace_name: development
       version_tag: ${{ needs.generate-tag.outputs.tag }}
+      apply: true
     secrets:
       aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
       aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -36,7 +36,7 @@
       "account_name": "preproduction",
       "is_production": false,
       "allowed_arns": [
-        "arn:aws:iam::936779158973:role/operator",
+        "arn:aws:iam::936779158973:role/breakglass",
         "arn:aws:iam::936779158973:role/lpa-store-ci",
         "arn:aws:iam::792093328875:role/preproduction-app-task-role"
       ]
@@ -46,7 +46,7 @@
       "account_name": "production",
       "is_production": true,
       "allowed_arns": [
-        "arn:aws:iam::764856231715:role/operator",
+        "arn:aws:iam::764856231715:role/breakglass",
         "arn:aws:iam::764856231715:role/lpa-store-ci",
         "arn:aws:iam::313879017102:role/production-app-task-role"
       ]


### PR DESCRIPTION
Operators shouldn't be able to call the API in non-development environments.

Also fix deployment to dev environment

#patch