### PR TITLE
Change openapi response mapping key to string

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -119,7 +119,7 @@ paths:
       operationId: healthCheck
       summary: Health check endpoint for external services to consume
       responses:
-        200:
+        "200":
           description: Healthy
           content:
             application/json:
@@ -130,7 +130,7 @@ paths:
                     type: string
                     example: OK
                 additionalProperties: false
-        503:
+        "503":
           description: Service unavailable
           content:
             application/json:


### PR DESCRIPTION
Change openapi response mapping key to string, which was caught by the linter when referencing this from sirius