### PR TITLE
Add EventBridge infrastructure

### DIFF
--- a/api-test/main.go
+++ b/api-test/main.go
@@ -87,6 +87,8 @@ func main() {
 		log.Printf("! TEST FAILED - %s to %s", method, url)
 		log.Printf("invalid status code %d; expected: %d", resp.StatusCode, *expectedStatusCode)
 		log.Printf("error response: %s", buf.String())
+
+		os.Exit(1)
 	} else {
 		log.Print(resp.Header)
 		log.Printf("Test passed - %s to %s - %d: %s", method, url, resp.StatusCode, buf.String())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       AWS_SECRET_ACCESS_KEY: localstack
       DDB_TABLE_NAME_DEEDS: deeds
       DDB_TABLE_NAME_CHANGES: changes
+      EVENT_BUS_NAME: local-main
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-secret}
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"
@@ -38,6 +39,7 @@ services:
       AWS_SECRET_ACCESS_KEY: localstack
       DDB_TABLE_NAME_DEEDS: deeds
       DDB_TABLE_NAME_CHANGES: changes
+      EVENT_BUS_NAME: local-main
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-secret}
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"
@@ -59,6 +61,7 @@ services:
       AWS_SECRET_ACCESS_KEY: localstack
       DDB_TABLE_NAME_DEEDS: deeds
       DDB_TABLE_NAME_CHANGES: changes
+      EVENT_BUS_NAME: local-main
       JWT_SECRET_KEY: ${JWT_SECRET_KEY:-secret}
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"

--- a/terraform/environment/eventbridge.tf
+++ b/terraform/environment/eventbridge.tf
@@ -1,0 +1,120 @@
+resource "aws_cloudwatch_event_bus" "main" {
+  name = "${local.environment_name}-main"
+
+  provider = aws.eu_west_1
+}
+
+resource "aws_cloudwatch_event_archive" "main" {
+  name             = "${local.environment_name}-main"
+  event_source_arn = aws_cloudwatch_event_bus.main.arn
+
+  provider = aws.eu_west_1
+}
+
+resource "aws_cloudwatch_event_rule" "source_events_to_sirius" {
+  event_bus_name = aws_cloudwatch_event_bus.main.name
+  name           = "${local.environment_name}-source-events-to-sirius"
+  state          = "ENABLED"
+  event_pattern = jsonencode({
+    source = ["opg.poas.lpastore"]
+  })
+
+  provider = aws.eu_west_1
+}
+
+resource "aws_kms_key" "event_dlq" {
+  description         = "KMS Key for ${local.environment_name} event dead-letter queue"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.event_dlq_kms_key.json
+  tags                = { "Name" = "event-dlq-kms-key-${local.environment_name}" }
+
+  provider = aws.eu_west_1
+}
+
+resource "aws_kms_alias" "event_dlq" {
+  name          = "alias/${local.environment_name}-event-dlq"
+  target_key_id = aws_kms_key.event_dlq.id
+
+  depends_on = [aws_kms_key.event_dlq]
+  provider   = aws.eu_west_1
+}
+
+resource "aws_sqs_queue" "event_dlq" {
+  name              = "${local.environment_name}-events-dlq"
+  kms_master_key_id = aws_kms_alias.event_dlq.name
+
+  provider = aws.eu_west_1
+}
+
+resource "aws_sqs_queue_policy" "deadletter_queue" {
+  queue_url = aws_sqs_queue.event_dlq.id
+  policy    = data.aws_iam_policy_document.deadletter_queue.json
+
+  provider = aws.eu_west_1
+}
+
+data "aws_iam_policy_document" "event_dlq_kms_key" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.environment.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid    = "Allow EventBridge to use key"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+
+  provider = aws.eu_west_1
+}
+
+data "aws_iam_policy_document" "deadletter_queue" {
+  statement {
+    sid       = "allowEB-${aws_cloudwatch_event_bus.main.name}"
+    effect    = "Allow"
+    resources = [aws_sqs_queue.event_dlq.arn]
+    actions = [
+      "sqs:SendMessage",
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.source_events_to_sirius.arn]
+    }
+  }
+
+  provider = aws.eu_west_1
+}
+
+module "eventbridge_cross_account_target" {
+  for_each              = toset(local.environment.target_event_buses)
+  source                = "../modules/eventbridge_cross_account_target"
+  name_suffix           = "${local.environment_name}-sirius"
+  rule                  = aws_cloudwatch_event_rule.source_events_to_sirius
+  dead_letter_queue_arn = aws_sqs_queue.event_dlq.arn
+  target_event_bus_arn  = each.value
+
+  providers = {
+    aws = aws.eu_west_1
+  }
+}

--- a/terraform/environment/region/iam.tf
+++ b/terraform/environment/region/iam.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "lambda_dynamodb_policy" {
   statement {
     sid       = "allowDynamoDB"
     effect    = "Allow"
-    resources = [var.dynamodb_arn]
+    resources = [var.dynamodb_arn, var.dynamodb_arn_changes]
     actions = [
       "dynamodb:PutItem",
       "dynamodb:GetItem",
@@ -67,4 +67,3 @@ data "aws_iam_policy_document" "lambda_s3_policy" {
     }
   }
 }
-

--- a/terraform/environment/region/lambda.tf
+++ b/terraform/environment/region/lambda.tf
@@ -18,6 +18,7 @@ module "lambda" {
   environment_variables = {
     DDB_TABLE_NAME_DEEDS   = var.dynamodb_name
     DDB_TABLE_NAME_CHANGES = var.dynamodb_name_changes
+    EVENT_BUS_NAME         = var.event_bus_name
     JWT_SECRET_KEY         = "secret"
   }
 

--- a/terraform/environment/region/lambda.tf
+++ b/terraform/environment/region/lambda.tf
@@ -13,12 +13,13 @@ module "lambda" {
   environment_name      = var.environment_name
   lambda_name           = each.key
   ecr_image_uri         = "${data.aws_ecr_repository.lambda[each.key].repository_url}:${var.app_version}"
+  event_bus_arn         = var.event_bus.arn
   cloudwatch_kms_key_id = aws_kms_key.cloudwatch.arn
 
   environment_variables = {
     DDB_TABLE_NAME_DEEDS   = var.dynamodb_name
     DDB_TABLE_NAME_CHANGES = var.dynamodb_name_changes
-    EVENT_BUS_NAME         = var.event_bus_name
+    EVENT_BUS_NAME         = var.event_bus.name
     JWT_SECRET_KEY         = "secret"
   }
 

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -39,9 +39,8 @@ variable "environment_name" {
   type        = string
 }
 
-variable "event_bus_name" {
-  description = "Name of event bus to send events to"
-  type        = string
+variable "event_bus" {
+  description = "Event bus to send events to"
 }
 
 variable "lpa_store_static_bucket" {

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -39,6 +39,11 @@ variable "environment_name" {
   type        = string
 }
 
+variable "event_bus_name" {
+  description = "Name of event bus to send events to"
+  type        = string
+}
+
 variable "lpa_store_static_bucket" {
   description = "LPA Store Static bucket object for the region"
 }

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -9,7 +9,7 @@ module "eu_west_1" {
   dynamodb_name                   = aws_dynamodb_table.deeds_table.name
   dynamodb_name_changes           = aws_dynamodb_table.changes_table.name
   environment_name                = local.environment_name
-  event_bus_name                  = aws_cloudwatch_event_bus.main.name
+  event_bus                       = aws_cloudwatch_event_bus.main
   lpa_store_static_bucket         = module.s3_lpa_store_static_eu_west_1.bucket
   lpa_store_static_bucket_kms_key = module.s3_lpa_store_static_eu_west_1.encryption_kms_key
 
@@ -30,7 +30,7 @@ module "eu_west_2" {
   dynamodb_name                   = aws_dynamodb_table.deeds_table.name
   dynamodb_name_changes           = aws_dynamodb_table.changes_table.name
   environment_name                = local.environment_name
-  event_bus_name                  = aws_cloudwatch_event_bus.main.name
+  event_bus                       = aws_cloudwatch_event_bus.main
   lpa_store_static_bucket         = module.s3_lpa_store_static_eu_west_2.bucket
   lpa_store_static_bucket_kms_key = module.s3_lpa_store_static_eu_west_2.encryption_kms_key
 

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -9,6 +9,7 @@ module "eu_west_1" {
   dynamodb_name                   = aws_dynamodb_table.deeds_table.name
   dynamodb_name_changes           = aws_dynamodb_table.changes_table.name
   environment_name                = local.environment_name
+  event_bus_name                  = aws_cloudwatch_event_bus.main.name
   lpa_store_static_bucket         = module.s3_lpa_store_static_eu_west_1.bucket
   lpa_store_static_bucket_kms_key = module.s3_lpa_store_static_eu_west_1.encryption_kms_key
 
@@ -29,6 +30,7 @@ module "eu_west_2" {
   dynamodb_name                   = aws_dynamodb_table.deeds_table.name
   dynamodb_name_changes           = aws_dynamodb_table.changes_table.name
   environment_name                = local.environment_name
+  event_bus_name                  = aws_cloudwatch_event_bus.main.name
   lpa_store_static_bucket         = module.s3_lpa_store_static_eu_west_2.bucket
   lpa_store_static_bucket_kms_key = module.s3_lpa_store_static_eu_west_2.encryption_kms_key
 

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -7,6 +7,9 @@
       "allowed_arns": [
         "arn:aws:iam::493907465011:role/operator",
         "arn:aws:iam::493907465011:role/lpa-store-ci"
+      ],
+      "target_event_buses": [
+        "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
       ]
     },
     "development": {
@@ -19,6 +22,9 @@
         "arn:aws:iam::653761790766:role/operator",
         "arn:aws:iam::653761790766:role/breakglass",
         "arn:aws:iam::653761790766:root"
+      ],
+      "target_event_buses": [
+        "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
       ]
     },
     "demo": {
@@ -29,6 +35,9 @@
         "arn:aws:iam::493907465011:role/operator",
         "arn:aws:iam::493907465011:role/lpa-store-ci",
         "arn:aws:iam::653761790766:role/demo-app-task-role"
+      ],
+      "target_event_buses": [
+        "arn:aws:events:eu-west-1:288342028542:event-bus/integration-poas"
       ]
     },
     "preproduction": {
@@ -39,6 +48,9 @@
         "arn:aws:iam::936779158973:role/breakglass",
         "arn:aws:iam::936779158973:role/lpa-store-ci",
         "arn:aws:iam::792093328875:role/preproduction-app-task-role"
+      ],
+      "target_event_buses": [
+        "arn:aws:events:eu-west-1:492687888235:event-bus/preproduction-poas"
       ]
     },
     "production": {
@@ -49,6 +61,9 @@
         "arn:aws:iam::764856231715:role/breakglass",
         "arn:aws:iam::764856231715:role/lpa-store-ci",
         "arn:aws:iam::313879017102:role/production-app-task-role"
+      ],
+      "target_event_buses": [
+        "arn:aws:events:eu-west-1:649098267436:event-bus/production-poas"
       ]
     }
   }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -26,10 +26,11 @@ locals {
 variable "environments" {
   type = map(
     object({
-      account_id    = string
-      account_name  = string
-      is_production = bool
-      allowed_arns  = list(string)
+      account_id         = string
+      account_name       = string
+      is_production      = bool
+      allowed_arns       = list(string)
+      target_event_buses = list(string)
     })
   )
 }

--- a/terraform/modules/eventbridge_cross_account_target/main.tf
+++ b/terraform/modules/eventbridge_cross_account_target/main.tf
@@ -1,0 +1,48 @@
+resource "aws_cloudwatch_event_target" "cross_account_event_bus" {
+  target_id      = "cross-account-put-${var.name_suffix}"
+  event_bus_name = var.rule.event_bus_name
+  rule           = var.rule.name
+  arn            = var.target_event_bus_arn
+  role_arn       = aws_iam_role.cross_account_put.arn
+
+  dead_letter_config {
+    arn = var.dead_letter_queue_arn
+  }
+}
+
+resource "aws_iam_role" "cross_account_put" {
+  name               = "cross-account-put-${var.name_suffix}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "cross_account_put" {
+  name   = "cross-account-put-${var.name_suffix}"
+  policy = data.aws_iam_policy_document.cross_account_put_access.json
+  role   = aws_iam_role.cross_account_put.id
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "cross_account_put_access" {
+  statement {
+    sid    = "CrossAccountPutAccess"
+    effect = "Allow"
+    actions = [
+      "events:PutEvents",
+    ]
+    resources = [
+      var.target_event_bus_arn
+    ]
+  }
+}

--- a/terraform/modules/eventbridge_cross_account_target/terraform.tf
+++ b/terraform/modules/eventbridge_cross_account_target/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.15.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+data "aws_region" "current" {}

--- a/terraform/modules/eventbridge_cross_account_target/variables.tf
+++ b/terraform/modules/eventbridge_cross_account_target/variables.tf
@@ -1,0 +1,22 @@
+variable "name_suffix" {
+  description = "Suffix to append to resource names to ensure enviornment/target uniqueness"
+  type        = string
+}
+
+variable "rule" {
+  description = "The rule that triggers this target"
+  type = object({
+    event_bus_name = string
+    name           = string
+  })
+}
+
+variable "target_event_bus_arn" {
+  description = "The ARN of the target event bus"
+  type        = string
+}
+
+variable "dead_letter_queue_arn" {
+  description = "The dead letter queue to send failed messages to"
+  type        = string
+}

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role_policy_attachment" "vpc_access_execution_role" {
 }
 
 resource "aws_iam_role_policy" "lambda" {
-  name   = "LambdaAllowLogging"
+  name   = "LambdaRolePermissions"
   role   = aws_iam_role.lambda.id
   policy = data.aws_iam_policy_document.lambda.json
 }
@@ -43,6 +43,15 @@ data "aws_iam_policy_document" "lambda" {
       "logs:CreateLogStream",
       "logs:PutLogEvents",
       "logs:DescribeLogStreams"
+    ]
+  }
+
+  statement {
+    sid       = "allowPutEvents"
+    effect    = "Allow"
+    resources = [var.event_bus_arn]
+    actions = [
+      "events:PutEvents"
     ]
   }
 }

--- a/terraform/modules/lambda/variables.tf
+++ b/terraform/modules/lambda/variables.tf
@@ -13,6 +13,11 @@ variable "ecr_image_uri" {
   type        = string
 }
 
+variable "event_bus_arn" {
+  description = "The ARN of the event bus to send update events to"
+  type        = string
+}
+
 variable "cloudwatch_kms_key_id" {
   description = "KMS key used to encrypt CloudWatch logs"
   type        = string


### PR DESCRIPTION
Includes:
- Event bus in LPA Store account
- Cross-account rule to send all locally-sourced events to the Sirius event bus
- Dead letter-queue to catch events that couldn't be sent

Fixes VEGA-2333 #minor