### PR TITLE
Add ADRs for unique actor IDs and authorisation

### DIFF
--- a/docs/architecture/decisions/0002-actor-unique-ids.md
+++ b/docs/architecture/decisions/0002-actor-unique-ids.md
@@ -1,0 +1,25 @@
+# 2. Actor unique IDs
+
+Date: 2024-03-12
+
+## Status
+
+Accepted
+
+## Context
+
+We need a consistent way to refer to each actor on an LPA: donor, certificate provider, attorneys, replacement attorneys and notified people.
+
+This comes from several needs:
+
+- Creating a clear audit trail when an actor makes changes to an LPA (e.g. when the certificate provider signs)
+- Clearly identifying actors across independent services, such as in event-driven messages
+- Ensuring changes to an actor are made against the right person, particularly when there are multiple actors of the same type on one LPA
+
+## Decision
+
+At the point of donor execution, all actors listed on an LPA will be assigned a v4 UUID that will not change past that point. If an actor already has a UUID (because an upstream service has assigned one) then it will not be overwritten.
+
+## Consequences
+
+We need to ensure that we use the unique ID across services rather than keeping local IDs that won't make sense to other services.

--- a/docs/architecture/decisions/0003-cross-service-authorisation.md
+++ b/docs/architecture/decisions/0003-cross-service-authorisation.md
@@ -1,0 +1,23 @@
+# 3. Cross-service authorisation
+
+Date: 2024-03-12
+
+## Status
+
+Accepted
+
+## Context
+
+When an LPA is created or updated in the LPA Store, we need to keep a record of who the initiator of the action is. This ensures we have an audit trail of all changes, whether they come from a member of the public, a member of staff at the OPG or an internal service.
+
+## Decision
+
+Requests to create or update an LPA will include a URN identifier to point to the source of the action. This will be in the format: `urn:opg:${service}:users:${identifier}`.
+
+For **members of the public using Make and Register**, the `service` will be "poas:mrlpa" and the `identifier` will be the actor's unique ID as stored on the LPA document (see ADR 2).
+
+For **OPG members of staff using Sirius**, the `service` will be "sirius" and the `identifier` will be the user's (numeric) user ID in Sirius.
+
+## Consequences
+
+As more services integrate with the LPA Store (e.g. scanning), we will need to expand this ADR to document what service and identifier(s) they will use.


### PR DESCRIPTION
Clarify how and when unique IDs for actors should be created.

Clarify the format of identifiers for cross-service authorisation.

#patch