### PR TITLE
Give fixtures container global egress

### DIFF
--- a/terraform/modules/fixtures_service/security_group.tf
+++ b/terraform/modules/fixtures_service/security_group.tf
@@ -35,7 +35,19 @@ data "aws_security_group" "vpc_endpoints_application" {
   provider = aws.region
 }
 
-resource "aws_security_group_rule" "lambda_to_vpc_gateways" {
+# Allow public web egress so we can access LPA Store APIs
+resource "aws_security_group_rule" "ecs_to_public_web" {
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  security_group_id = aws_security_group.ecs.id
+  cidr_blocks       = ["0.0.0.0/0"]
+
+  provider = aws.region
+}
+
+resource "aws_security_group_rule" "ecs_to_vpc_gateways" {
   type              = "egress"
   protocol          = "tcp"
   from_port         = 443


### PR DESCRIPTION
Since we're accessing the LPA Store API over the public web, and we can't determine its IP address, we need to allow public egress for the ECS container.

For VEGA-2424 #minor