### PR TITLE
Allow ephemeral Sirius environments to access dev

### DIFF
--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -3,6 +3,11 @@ variable "allowed_arns" {
   type        = list(string)
 }
 
+variable "allowed_wildcard_arns" {
+  description = "List of wildcard-containing external ARNs allowed to access the API Gateway"
+  type        = list(string)
+}
+
 variable "account_name" {
   description = "Name of AWS account"
   type        = string

--- a/terraform/environment/regions.tf
+++ b/terraform/environment/regions.tf
@@ -2,6 +2,7 @@ module "eu_west_1" {
   source = "./region"
 
   allowed_arns                    = local.environment.allowed_arns
+  allowed_wildcard_arns           = local.environment.allowed_wildcard_arns
   account_name                    = local.environment.account_name
   app_version                     = var.app_version
   dns_weighting                   = 100
@@ -26,6 +27,7 @@ module "eu_west_2" {
   source = "./region"
 
   allowed_arns                    = local.environment.allowed_arns
+  allowed_wildcard_arns           = local.environment.allowed_wildcard_arns
   account_name                    = local.environment.account_name
   app_version                     = var.app_version
   dns_weighting                   = 0

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -25,6 +25,9 @@
         "arn:aws:iam::653761790766:role/breakglass",
         "arn:aws:iam::653761790766:root"
       ],
+      "allowed_wildcard_arns": [
+        "arn:aws:iam::288342028542:role/api-ecs-*"
+      ],
       "target_event_buses": [
         "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
       ]

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -26,12 +26,13 @@ locals {
 variable "environments" {
   type = map(
     object({
-      account_id         = string
-      account_name       = string
-      is_production      = bool
-      has_fixtures       = bool
-      allowed_arns       = list(string)
-      target_event_buses = list(string)
+      account_id            = string
+      account_name          = string
+      is_production         = bool
+      has_fixtures          = bool
+      allowed_arns          = list(string)
+      allowed_wildcard_arns = optional(list(string), [])
+      target_event_buses    = list(string)
     })
   )
 }


### PR DESCRIPTION
Introduces a new optional `allowed_wildcard_arns` environment property because wildcard ARNs need to be configured differently.

Will allow Sirius popup environments to work automatically.

Discovered during VEGA-2424 #minor