### PR TITLE
MLPAB-1223 Omit fields that are optional from LpaInit

### DIFF
--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -8,20 +8,20 @@ type LpaInit struct {
 	LpaType                                     LpaType                 `json:"lpaType"`
 	Donor                                       Donor                   `json:"donor"`
 	Attorneys                                   []Attorney              `json:"attorneys"`
-	TrustCorporations                           []TrustCorporation      `json:"trustCorporations"`
+	TrustCorporations                           []TrustCorporation      `json:"trustCorporations,omitempty"`
 	CertificateProvider                         CertificateProvider     `json:"certificateProvider"`
-	PeopleToNotify                              []PersonToNotify        `json:"peopleToNotify"`
-	HowAttorneysMakeDecisions                   HowMakeDecisions        `json:"howAttorneysMakeDecisions"`
-	HowAttorneysMakeDecisionsDetails            string                  `json:"howAttorneysMakeDecisionsDetails"`
-	HowReplacementAttorneysMakeDecisions        HowMakeDecisions        `json:"howReplacementAttorneysMakeDecisions"`
-	HowReplacementAttorneysMakeDecisionsDetails string                  `json:"howReplacementAttorneysMakeDecisionsDetails"`
-	HowReplacementAttorneysStepIn               HowStepIn               `json:"howReplacementAttorneysStepIn"`
-	HowReplacementAttorneysStepInDetails        string                  `json:"howReplacementAttorneysStepInDetails"`
-	WhenTheLpaCanBeUsed                         CanUse                  `json:"whenTheLpaCanBeUsed"`
-	LifeSustainingTreatmentOption               LifeSustainingTreatment `json:"lifeSustainingTreatmentOption"`
-	RestrictionsAndConditions                   string                  `json:"restrictionsAndConditions"`
+	PeopleToNotify                              []PersonToNotify        `json:"peopleToNotify,omitempty"`
+	HowAttorneysMakeDecisions                   HowMakeDecisions        `json:"howAttorneysMakeDecisions,omitempty"`
+	HowAttorneysMakeDecisionsDetails            string                  `json:"howAttorneysMakeDecisionsDetails,omitempty"`
+	HowReplacementAttorneysMakeDecisions        HowMakeDecisions        `json:"howReplacementAttorneysMakeDecisions,omitempty"`
+	HowReplacementAttorneysMakeDecisionsDetails string                  `json:"howReplacementAttorneysMakeDecisionsDetails,omitempty"`
+	HowReplacementAttorneysStepIn               HowStepIn               `json:"howReplacementAttorneysStepIn,omitempty"`
+	HowReplacementAttorneysStepInDetails        string                  `json:"howReplacementAttorneysStepInDetails,omitempty"`
+	WhenTheLpaCanBeUsed                         CanUse                  `json:"whenTheLpaCanBeUsed,omitempty"`
+	LifeSustainingTreatmentOption               LifeSustainingTreatment `json:"lifeSustainingTreatmentOption,omitempty"`
+	RestrictionsAndConditions                   string                  `json:"restrictionsAndConditions,omitempty"`
 	SignedAt                                    time.Time               `json:"signedAt"`
-	CertificateProviderNotRelatedConfirmedAt    *time.Time              `json:"certificateProviderNotRelatedConfirmedAt"`
+	CertificateProviderNotRelatedConfirmedAt    *time.Time              `json:"certificateProviderNotRelatedConfirmedAt,omitempty"`
 }
 
 type Lpa struct {

--- a/internal/shared/lpa_test.go
+++ b/internal/shared/lpa_test.go
@@ -1,0 +1,21 @@
+package shared
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLpaInitMarshalJSON(t *testing.T) {
+	expected := `{
+"lpaType":"",
+"donor":{"firstNames":"","lastName":"","address":{"line1":"","line2":"","line3":"","town":"","postcode":"","country":""},"dateOfBirth":"0001-01-01T00:00:00Z","email":"","otherNamesKnownBy":""},
+"attorneys":null,
+"certificateProvider":{"firstNames":"","lastName":"","address":{"line1":"","line2":"","line3":"","town":"","postcode":"","country":""},"email":"","phone":"","channel":"","signedAt":"0001-01-01T00:00:00Z"},
+"signedAt":"0001-01-01T00:00:00Z"
+}`
+
+	data, _ := json.Marshal(LpaInit{})
+	assert.JSONEq(t, expected, string(data))
+}


### PR DESCRIPTION
I think this is preferable to returning data to clients with both `lifeSustainingTreatmentOption` and `whenTheLpaCanBeUsed`, for example. I've extended it to all the (top-level) things that are optional, but are enforced by validation in create.