### PR TITLE
vega-2343 - Remove email validation in jwt sub

### DIFF
--- a/api-test/main.go
+++ b/api-test/main.go
@@ -132,7 +132,7 @@ func makeJwt(secretKey []byte) string {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone@someplace.somewhere.com",
+		"sub": "urn:opg:sirius:users:34",
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/internal/shared/jwt.go
+++ b/internal/shared/jwt.go
@@ -72,11 +72,6 @@ func (l LpaStoreClaims) Validate() error {
 		switch iss {
 		case mrlpa:
 			return errors.New("Subject is not a valid URN")
-		case sirius:
-			emailRegex := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-			if !emailRegex.MatchString(sub) {
-				return errors.New("Subject is not a valid email or URN")
-			}
 		}
 	}
 

--- a/internal/shared/jwt.go
+++ b/internal/shared/jwt.go
@@ -69,10 +69,7 @@ func (l LpaStoreClaims) Validate() error {
 	_, isUrn := urn.Parse([]byte(sub))
 
 	if !isUrn {
-		switch iss {
-		case mrlpa:
-			return errors.New("Subject is not a valid URN")
-		}
+		return errors.New("Subject is not a valid URN")
 	}
 
 	return nil

--- a/internal/shared/jwt_test.go
+++ b/internal/shared/jwt_test.go
@@ -50,7 +50,7 @@ func TestVerifyIatInFuture(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * 24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone",
+		"sub": "urn:opg:sirius:users:34",
 	})
 
 	_, err := verifier.verifyToken(token)
@@ -66,7 +66,7 @@ func TestVerifyIssuer(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "daadsdaadsadsads",
-		"sub": "someone",
+		"sub": "urn:opg:poas:makeregister:users:e6707412-c9cd-4547-b428-7039a87e985e",
 	})
 
 	_, err := verifier.verifyToken(token)
@@ -74,6 +74,22 @@ func TestVerifyIssuer(t *testing.T) {
 	assert.NotNil(t, err)
 	if err != nil {
 		assert.Containsf(t, err.Error(), "Invalid Issuer", "")
+	}
+}
+
+func TestVerifyBadSubForSiriusIssuer(t *testing.T) {
+	token := createToken(jwt.MapClaims{
+		"exp": time.Now().Add(time.Hour * 24).Unix(),
+		"iat": time.Now().Add(time.Hour * -24).Unix(),
+		"iss": "opg.poas.sirius",
+		"sub": "",
+	})
+
+	_, err := verifier.verifyToken(token)
+
+	assert.NotNil(t, err)
+	if err != nil {
+		assert.Containsf(t, err.Error(), "Subject is not a valid URN", "")
 	}
 }
 
@@ -98,20 +114,10 @@ func TestVerifyGoodJwtSiriusSubs(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone",
-	})
-
-	_, err := verifier.verifyToken(token)
-	assert.Nil(t, err)
-
-	token = createToken(jwt.MapClaims{
-		"exp": time.Now().Add(time.Hour * 24).Unix(),
-		"iat": time.Now().Add(time.Hour * -24).Unix(),
-		"iss": "opg.poas.sirius",
 		"sub": "urn:opg:sirius:users:34",
 	})
 
-	_, err = verifier.verifyToken(token)
+	_, err := verifier.verifyToken(token)
 	assert.Nil(t, err)
 }
 
@@ -141,7 +147,7 @@ func TestVerifyHeader(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone",
+		"sub": "urn:opg:sirius:users:34",
 	})
 
 	event := events.APIGatewayProxyRequest{

--- a/internal/shared/jwt_test.go
+++ b/internal/shared/jwt_test.go
@@ -50,7 +50,7 @@ func TestVerifyIatInFuture(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * 24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone@someplace.somewhere.com",
+		"sub": "someone",
 	})
 
 	_, err := verifier.verifyToken(token)
@@ -66,7 +66,7 @@ func TestVerifyIssuer(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "daadsdaadsadsads",
-		"sub": "someone@someplace.somewhere.com",
+		"sub": "someone",
 	})
 
 	_, err := verifier.verifyToken(token)
@@ -74,22 +74,6 @@ func TestVerifyIssuer(t *testing.T) {
 	assert.NotNil(t, err)
 	if err != nil {
 		assert.Containsf(t, err.Error(), "Invalid Issuer", "")
-	}
-}
-
-func TestVerifyBadSubForSiriusIssuer(t *testing.T) {
-	token := createToken(jwt.MapClaims{
-		"exp": time.Now().Add(time.Hour * 24).Unix(),
-		"iat": time.Now().Add(time.Hour * -24).Unix(),
-		"iss": "opg.poas.sirius",
-		"sub": "",
-	})
-
-	_, err := verifier.verifyToken(token)
-
-	assert.NotNil(t, err)
-	if err != nil {
-		assert.Containsf(t, err.Error(), "Subject is not a valid email or URN", "")
 	}
 }
 
@@ -114,7 +98,7 @@ func TestVerifyGoodJwtSiriusSubs(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone@someplace.somewhere.com",
+		"sub": "someone",
 	})
 
 	_, err := verifier.verifyToken(token)
@@ -157,7 +141,7 @@ func TestVerifyHeader(t *testing.T) {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "someone@someplace.somewhere.com",
+		"sub": "someone",
 	})
 
 	event := events.APIGatewayProxyRequest{


### PR DESCRIPTION
We no longer need to support email address sub values for validation in the LPA store.

Update [jwt.go](https://github.com/ministryofjustice/opg-data-lpa-store/blob/d23d519270bff83961ad59e12f2d87d5f8e8dbe9/internal/shared/jwt.go) to remove email address validation for sub fields.

[vega-2342](https://opgtransform.atlassian.net/browse/VEGA-2343)