### PR TITLE
Fix environment destruction

### DIFF
--- a/.github/workflows/env-destroy.yml
+++ b/.github/workflows/env-destroy.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.allowlist_deploy_key }}
 
+      # AWS API Gateway doesn't support OpenAPI 3.1, so downgrade to 3.0
+      - name: Compile OpenAPI file
+        run: make build-apigw-openapi-spec
+
       - name: Lint Terraform
         run: terraform fmt -check -recursive
         working-directory: ./terraform/environment


### PR DESCRIPTION
Need to have OpenAPI file in order to run `terraform destroy`.

This has left a few environments undestroyed, so I'll come back to make this workflow dispatchable by environment name

#patch