### PR TITLE
MLPAB-1546: Enforce matching old and existing for CERTIFICATE_PROVIDER_SIGN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,13 @@ test-api:
 	JWT_SECRET_KEY=bad ./api-test/tester -expectedStatus=401 REQUEST PUT $(URL)/lpas/$(LPA_UID) '{"version":"1"}'
 	JWT_SECRET_KEY=bad ./api-test/tester -expectedStatus=401 REQUEST POST $(URL)/lpas/$(LPA_UID)/updates '{"type":"BUMP_VERSION","changes":[{"key":"/version","old":"1","new":"2"}]}'
 	JWT_SECRET_KEY=bad ./api-test/tester -expectedStatus=401 REQUEST GET $(URL)/lpas/$(LPA_UID) ''
+
 	cat ./docs/example-lpa.json | ./api-test/tester -expectedStatus=201 REQUEST PUT $(URL)/lpas/$(LPA_UID) "`xargs -0`"
 	./api-test/tester -expectedStatus=200 -write REQUEST GET $(URL)/lpas/$(LPA_UID) '' > $(TMPFILE)
+
 	diff <(jq --sort-keys 'del(.status,.uid,.updatedAt)' < $(TMPFILE)) <(jq --sort-keys . < docs/example-lpa.json)
 	./api-test/tester -expectedStatus=400 REQUEST PUT $(URL)/lpas/$(LPA_UID) '{"version":"2"}'
+
 	cat ./docs/certificate-provider-change.json | ./api-test/tester -expectedStatus=201 REQUEST POST $(URL)/lpas/$(LPA_UID)/updates "`xargs -0`"
 	./api-test/tester -expectedStatus=200 REQUEST GET $(URL)/lpas/$(LPA_UID) ''
 .PHONY: test-api

--- a/docs/certificate-provider-change.json
+++ b/docs/certificate-provider-change.json
@@ -4,17 +4,17 @@
         {
             "key": "/certificateProvider/address/line1",
             "new": "98 CVVVV",
-            "old": null
+            "old": "122111 Zonnington Way"
         },
         {
             "key": "/certificateProvider/address/town",
             "new": "Murkkkk Town",
-            "old": null
+            "old": "Mahhhhhhhhhh"
         },
         {
             "key": "/certificateProvider/address/country",
             "new": "GB",
-            "old": null
+            "old": "GB"
         },
         {
             "key": "/certificateProvider/signedAt",
@@ -34,7 +34,7 @@
         {
             "key": "/certificateProvider/channel",
             "new": "online",
-            "old": "paper"
+            "old": "online"
         }
     ]
 }

--- a/docs/example-lpa.json
+++ b/docs/example-lpa.json
@@ -38,7 +38,7 @@
       "country": "GB"
     },
     "channel": "online",
-    "email": "nobody3@not.a.real.domain",
+    "email": "a@example.com",
     "phone": "070009000"
   },
   "lifeSustainingTreatmentOption": "option-a",

--- a/lambda/update/certificate_provider_sign.go
+++ b/lambda/update/certificate_provider_sign.go
@@ -49,12 +49,12 @@ func validateCertificateProviderSign(changes []shared.Change, lpa *shared.Lpa) (
 				Field("/line2", &data.Address.Line2, parse.Optional(), parse.MustMatchExisting()).
 				Field("/line3", &data.Address.Line3, parse.Optional(), parse.MustMatchExisting()).
 				Field("/town", &data.Address.Town, parse.MustMatchExisting()).
-				Field("/postcode", &data.Address.Postcode, parse.Optional()).
+				Field("/postcode", &data.Address.Postcode, parse.Optional(), parse.MustMatchExisting()).
 				Field("/country", &data.Address.Country, parse.Validate(func() []shared.FieldError {
 					return validate.Country("", data.Address.Country)
-				})).
+				}), parse.MustMatchExisting()).
 				Consumed()
-		}, parse.Optional(), parse.MustMatchExisting()).
+		}, parse.Optional()).
 		Field("/certificateProvider/signedAt", &data.SignedAt, parse.Validate(func() []shared.FieldError {
 			return validate.Time("", data.SignedAt)
 		}), parse.MustMatchExisting()).

--- a/lambda/update/certificate_provider_sign.go
+++ b/lambda/update/certificate_provider_sign.go
@@ -45,28 +45,28 @@ func validateCertificateProviderSign(changes []shared.Change, lpa *shared.Lpa) (
 	errors := parse.Changes(changes).
 		Prefix("/certificateProvider/address", func(p *parse.Parser) []shared.FieldError {
 			return p.
-				Field("/line1", &data.Address.Line1).
-				Field("/line2", &data.Address.Line2, parse.Optional()).
-				Field("/line3", &data.Address.Line3, parse.Optional()).
-				Field("/town", &data.Address.Town).
+				Field("/line1", &data.Address.Line1, parse.MustMatchExisting()).
+				Field("/line2", &data.Address.Line2, parse.Optional(), parse.MustMatchExisting()).
+				Field("/line3", &data.Address.Line3, parse.Optional(), parse.MustMatchExisting()).
+				Field("/town", &data.Address.Town, parse.MustMatchExisting()).
 				Field("/postcode", &data.Address.Postcode, parse.Optional()).
 				Field("/country", &data.Address.Country, parse.Validate(func() []shared.FieldError {
 					return validate.Country("", data.Address.Country)
 				})).
 				Consumed()
-		}, parse.Optional()).
+		}, parse.Optional(), parse.MustMatchExisting()).
 		Field("/certificateProvider/signedAt", &data.SignedAt, parse.Validate(func() []shared.FieldError {
 			return validate.Time("", data.SignedAt)
-		})).
+		}), parse.MustMatchExisting()).
 		Field("/certificateProvider/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(func() []shared.FieldError {
 			return validate.IsValid("", data.ContactLanguagePreference)
-		})).
+		}), parse.MustMatchExisting()).
 		Field("/certificateProvider/email", &data.Email, parse.Validate(func() []shared.FieldError {
 			return validate.Required("", data.Email)
-		}), parse.Optional()).
+		}), parse.Optional(), parse.MustMatchExisting()).
 		Field("/certificateProvider/channel", &data.Channel, parse.Validate(func() []shared.FieldError {
 			return validate.IsValid("", data.Channel)
-		}), parse.Optional()).
+		}), parse.Optional(), parse.MustMatchExisting()).
 		Consumed()
 
 	return data, errors

--- a/lambda/update/certificate_provider_sign_test.go
+++ b/lambda/update/certificate_provider_sign_test.go
@@ -68,7 +68,7 @@ func TestValidateUpdateCertificateProviderSign(t *testing.T) {
 					},
 					{
 						Key: "/certificateProvider/signedAt",
-						New: json.RawMessage(`"` + now.Format(time.RFC3339) + `"`),
+						New: json.RawMessage(`"` + now.Format(time.RFC3339Nano) + `"`),
 						Old: jsonNull,
 					},
 					{
@@ -138,8 +138,8 @@ func TestValidateUpdateCertificateProviderSign(t *testing.T) {
 					},
 					{
 						Key: "/certificateProvider/signedAt",
-						New: json.RawMessage(`"` + now.Format(time.RFC3339) + `"`),
-						Old: json.RawMessage(`"` + yesterday.Format(time.RFC3339) + `"`),
+						New: json.RawMessage(`"` + now.Format(time.RFC3339Nano) + `"`),
+						Old: json.RawMessage(`"` + yesterday.Format(time.RFC3339Nano) + `"`),
 					},
 					{
 						Key: "/certificateProvider/contactLanguagePreference",

--- a/lambda/update/parse/changes.go
+++ b/lambda/update/parse/changes.go
@@ -149,12 +149,12 @@ func oldEqualsExisting(old any, existing any) bool {
 			return v.IsZero()
 		}
 
-		oldTime, err := time.Parse(time.RFC3339, old.(string))
+		oldTime, err := time.Parse(time.RFC3339Nano, old.(string))
 		if err != nil {
 			return false
 		}
 
-		return oldTime.Equal(v.Truncate(time.Second))
+		return oldTime.Equal(*v)
 
 	case *shared.Lang:
 		if old == nil {

--- a/lambda/update/parse/changes.go
+++ b/lambda/update/parse/changes.go
@@ -154,7 +154,7 @@ func oldEqualsExisting(old any, existing any) bool {
 			return false
 		}
 
-		return oldTime.Equal(*v)
+		return oldTime.Equal(v.Truncate(time.Second))
 
 	case *shared.Lang:
 		if old == nil {

--- a/lambda/update/parse/changes_test.go
+++ b/lambda/update/parse/changes_test.go
@@ -104,7 +104,7 @@ func TestFieldMustMatchExistingTime(t *testing.T) {
 	yesterday := time.Now().Add(-24 * time.Hour)
 
 	changes := []shared.Change{
-		{Key: "/thing", New: json.RawMessage(`"` + now.Format(time.RFC3339) + `"`), Old: json.RawMessage(`"` + yesterday.Format(time.RFC3339) + `"`)},
+		{Key: "/thing", New: json.RawMessage(`"` + now.Format(time.RFC3339Nano) + `"`), Old: json.RawMessage(`"` + yesterday.Format(time.RFC3339Nano) + `"`)},
 	}
 
 	Changes(changes).Field("/thing", &yesterday, MustMatchExisting())

--- a/lambda/update/parse/changes_test.go
+++ b/lambda/update/parse/changes_test.go
@@ -104,7 +104,7 @@ func TestFieldMustMatchExistingTime(t *testing.T) {
 	yesterday := time.Now().Add(-24 * time.Hour)
 
 	changes := []shared.Change{
-		{Key: "/thing", New: json.RawMessage(`"` + now.Format(time.RFC3339Nano) + `"`), Old: json.RawMessage(`"` + yesterday.Format(time.RFC3339Nano) + `"`)},
+		{Key: "/thing", New: json.RawMessage(`"` + now.Format(time.RFC3339) + `"`), Old: json.RawMessage(`"` + yesterday.Format(time.RFC3339) + `"`)},
 	}
 
 	Changes(changes).Field("/thing", &yesterday, MustMatchExisting())


### PR DESCRIPTION
Confirmed this is working now we match the hardcoded API Gateway mock values for an existing LPA:

![Screenshot 2024-04-19 at 16 11 50](https://github.com/ministryofjustice/opg-data-lpa-store/assets/17926619/d506e53e-cdfb-46d1-81eb-bb9a5f5a6b63)

We'll go through this for attorneys and trust corps next and then drop the `MustMatchExisting` opt.

I think longer term it would be useful to either define what some existing values in the LPA are as part of the test (e.g. `An LPA exists with UID XXX and Address 1 fake road, town, postcode etc`) or pull in the existing values from a central repository as its unclear from the consumer side what existing values need to be provided and where they are defined

Fixes MLPAB-1546