### PR TITLE
MLPAB-2088: Make email optional, channel required for create trust corporation

### DIFF
--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -124,8 +124,11 @@ func validateTrustCorporation(prefix string, trustCorporation shared.TrustCorpor
 		validate.UUID(fmt.Sprintf("%s/uid", prefix), trustCorporation.UID),
 		validate.Required(fmt.Sprintf("%s/name", prefix), trustCorporation.Name),
 		validate.Required(fmt.Sprintf("%s/companyNumber", prefix), trustCorporation.CompanyNumber),
-		validate.Required(fmt.Sprintf("%s/email", prefix), trustCorporation.Email),
 		validate.Address(fmt.Sprintf("%s/address", prefix), trustCorporation.Address),
+		validate.IsValid(fmt.Sprintf("%s/channel", prefix), trustCorporation.Channel),
 		validate.IsValid(fmt.Sprintf("%s/status", prefix), trustCorporation.Status),
+		validate.IfElse(trustCorporation.Channel == shared.ChannelOnline,
+			validate.Required(fmt.Sprintf("%s/email", prefix), trustCorporation.Email),
+			validate.Empty(fmt.Sprintf("%s/email", prefix), trustCorporation.Email)),
 	)
 }

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -127,8 +127,8 @@ func validateTrustCorporation(prefix string, trustCorporation shared.TrustCorpor
 		validate.Address(fmt.Sprintf("%s/address", prefix), trustCorporation.Address),
 		validate.IsValid(fmt.Sprintf("%s/channel", prefix), trustCorporation.Channel),
 		validate.IsValid(fmt.Sprintf("%s/status", prefix), trustCorporation.Status),
-		validate.IfElse(trustCorporation.Channel == shared.ChannelOnline,
-			validate.Required(fmt.Sprintf("%s/email", prefix), trustCorporation.Email),
-			validate.Empty(fmt.Sprintf("%s/email", prefix), trustCorporation.Email)),
+		//validate.IfElse(trustCorporation.Channel == shared.ChannelOnline,
+		//	validate.Required(fmt.Sprintf("%s/email", prefix), trustCorporation.Email),
+		//	validate.Empty(fmt.Sprintf("%s/email", prefix), trustCorporation.Email)),
 	)
 }

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -299,31 +299,31 @@ func TestValidateLpaInvalid(t *testing.T) {
 				{Source: "/lifeSustainingTreatmentOption", Detail: "field must not be provided"},
 			},
 		},
-		"online trust corporation missing email": {
-			lpa: shared.LpaInit{
-				TrustCorporations: []shared.TrustCorporation{
-					{
-						Channel: shared.ChannelOnline,
-					},
-				},
-			},
-			contains: []shared.FieldError{
-				{Source: "/trustCorporations/0/email", Detail: "field is required"},
-			},
-		},
-		"paper trust corporation with email": {
-			lpa: shared.LpaInit{
-				TrustCorporations: []shared.TrustCorporation{
-					{
-						Channel: shared.ChannelPaper,
-						Email:   "a@example.com",
-					},
-				},
-			},
-			contains: []shared.FieldError{
-				{Source: "/trustCorporations/0/email", Detail: "field must not be provided"},
-			},
-		},
+		//"online trust corporation missing email": {
+		//	lpa: shared.LpaInit{
+		//		TrustCorporations: []shared.TrustCorporation{
+		//			{
+		//				Channel: shared.ChannelOnline,
+		//			},
+		//		},
+		//	},
+		//	contains: []shared.FieldError{
+		//		{Source: "/trustCorporations/0/email", Detail: "field is required"},
+		//	},
+		//},
+		//"paper trust corporation with email": {
+		//	lpa: shared.LpaInit{
+		//		TrustCorporations: []shared.TrustCorporation{
+		//			{
+		//				Channel: shared.ChannelPaper,
+		//				Email:   "a@example.com",
+		//			},
+		//		},
+		//	},
+		//	contains: []shared.FieldError{
+		//		{Source: "/trustCorporations/0/email", Detail: "field must not be provided"},
+		//	},
+		//},
 	}
 
 	for name, tc := range testcases {

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -100,10 +100,10 @@ func TestValidateTrustCorporationEmpty(t *testing.T) {
 
 	assert.Contains(t, errors, shared.FieldError{Source: "/test/name", Detail: "field is required"})
 	assert.Contains(t, errors, shared.FieldError{Source: "/test/companyNumber", Detail: "field is required"})
-	assert.Contains(t, errors, shared.FieldError{Source: "/test/email", Detail: "field is required"})
 	assert.Contains(t, errors, shared.FieldError{Source: "/test/status", Detail: "field is required"})
 	assert.Contains(t, errors, shared.FieldError{Source: "/test/address/line1", Detail: "field is required"})
 	assert.Contains(t, errors, shared.FieldError{Source: "/test/address/country", Detail: "field is required"})
+	assert.Contains(t, errors, shared.FieldError{Source: "/test/channel", Detail: "field is required"})
 }
 
 func TestValidateTrustCorporationValid(t *testing.T) {
@@ -114,6 +114,7 @@ func TestValidateTrustCorporationValid(t *testing.T) {
 		Email:         "corp@example.com",
 		Address:       validAddress,
 		Status:        shared.AttorneyStatusActive,
+		Channel:       shared.ChannelOnline,
 	}
 	errors := validateTrustCorporation("/test", trustCorporation)
 
@@ -296,6 +297,31 @@ func TestValidateLpaInvalid(t *testing.T) {
 			contains: []shared.FieldError{
 				{Source: "/whenTheLpaCanBeUsed", Detail: "field is required"},
 				{Source: "/lifeSustainingTreatmentOption", Detail: "field must not be provided"},
+			},
+		},
+		"online trust corporation missing email": {
+			lpa: shared.LpaInit{
+				TrustCorporations: []shared.TrustCorporation{
+					{
+						Channel: shared.ChannelOnline,
+					},
+				},
+			},
+			contains: []shared.FieldError{
+				{Source: "/trustCorporations/0/email", Detail: "field is required"},
+			},
+		},
+		"paper trust corporation with email": {
+			lpa: shared.LpaInit{
+				TrustCorporations: []shared.TrustCorporation{
+					{
+						Channel: shared.ChannelPaper,
+						Email:   "a@example.com",
+					},
+				},
+			},
+			contains: []shared.FieldError{
+				{Source: "/trustCorporations/0/email", Detail: "field must not be provided"},
 			},
 		},
 	}


### PR DESCRIPTION
Partially fixes [MLPAB-2088](https://opgtransform.atlassian.net/browse/MLPAB-2088). As part of the MRLPA work we will be making email an optional field for trust corps so we can infer the channel.

I'll come back and uncomment the validation for channel + email once consumer tests are updated.