### PR TITLE
MLPAB-1269: Support CERTIFICATE_PROVIDER_OPT_OUT update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-api:
 	# certificate provider opt out
 	$(eval LPA_UID := "$(shell ./api-test/tester UID)")
 	cat ./docs/example-lpa.json | ./api-test/tester -expectedStatus=201 REQUEST PUT $(URL)/lpas/$(LPA_UID) "`xargs -0`"
-	./api-test/tester -expectedStatus=200 -write REQUEST GET $(URL)/lpas/$(LPA_UID) '' > $(TMPFILE)
+	./api-test/tester -expectedStatus=200 REQUEST GET $(URL)/lpas/$(LPA_UID) ''
 	cat ./docs/certificate-provider-opt-out.json | ./api-test/tester -expectedStatus=201 REQUEST POST $(URL)/lpas/$(LPA_UID)/updates "`xargs -0`"
 
 .PHONY: test-api

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,13 @@ test-api:
 
 	# get lpas
 	./api-test/tester -expectedStatus=200 REQUEST POST $(URL)/lpas '{"uids": [$(LPA_UID)]}'
+
+	# certificate provider opt out
+	$(eval LPA_UID := "$(shell ./api-test/tester UID)")
+	cat ./docs/example-lpa.json | ./api-test/tester -expectedStatus=201 REQUEST PUT $(URL)/lpas/$(LPA_UID) "`xargs -0`"
+	./api-test/tester -expectedStatus=200 -write REQUEST GET $(URL)/lpas/$(LPA_UID) '' > $(TMPFILE)
+	cat ./docs/certificate-provider-opt-out.json | ./api-test/tester -expectedStatus=201 REQUEST POST $(URL)/lpas/$(LPA_UID)/updates "`xargs -0`"
+
 .PHONY: test-api
 
 test-pact:

--- a/docs/certificate-provider-opt-out.json
+++ b/docs/certificate-provider-opt-out.json
@@ -1,0 +1,4 @@
+{
+  "type": "CERTIFICATE_PROVIDER_OPT_OUT",
+  "changes": []
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -267,6 +267,7 @@ components:
             - TRUST_CORPORATION_SIGN
             - PERFECT
             - REGISTER
+            - CERTIFICATE_PROVIDER_OPT_OUT
         changes:
           type: array
           items:

--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -46,7 +46,8 @@ func (e LpaType) IsValid() bool {
 type LpaStatus string
 
 const (
-	LpaStatusProcessing = LpaStatus("processing")
-	LpaStatusPerfect    = LpaStatus("perfect")
-	LpaStatusRegistered = LpaStatus("registered")
+	LpaStatusProcessing     = LpaStatus("processing")
+	LpaStatusPerfect        = LpaStatus("perfect")
+	LpaStatusRegistered     = LpaStatus("registered")
+	LpaStatusCannotRegister = LpaStatus("cannot-register")
 )

--- a/lambda/update/certificate_provider_opt_out.go
+++ b/lambda/update/certificate_provider_opt_out.go
@@ -1,0 +1,28 @@
+package main
+
+import "github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+
+type CertificateProviderOptOut struct{}
+
+func (c CertificateProviderOptOut) Apply(lpa *shared.Lpa) []shared.FieldError {
+	emptyCertificateProvider := shared.CertificateProvider{}
+	if lpa.CertificateProvider == emptyCertificateProvider {
+		return []shared.FieldError{{Source: "/type", Detail: "certificate provider not present on LPA"}}
+	}
+
+	if lpa.CertificateProvider.SignedAt != nil && !lpa.CertificateProvider.SignedAt.IsZero() {
+		return []shared.FieldError{{Source: "/type", Detail: "certificate provider cannot opt out after providing certificate"}}
+	}
+
+	lpa.CertificateProvider = shared.CertificateProvider{}
+
+	return nil
+}
+
+func validateCertificateProviderOptOut(changes []shared.Change) (CertificateProviderOptOut, []shared.FieldError) {
+	if len(changes) > 0 {
+		return CertificateProviderOptOut{}, []shared.FieldError{{Source: "/changes", Detail: "expected empty"}}
+	}
+
+	return CertificateProviderOptOut{}, nil
+}

--- a/lambda/update/certificate_provider_opt_out.go
+++ b/lambda/update/certificate_provider_opt_out.go
@@ -5,17 +5,11 @@ import "github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 type CertificateProviderOptOut struct{}
 
 func (c CertificateProviderOptOut) Apply(lpa *shared.Lpa) []shared.FieldError {
-	emptyCertificateProvider := shared.CertificateProvider{}
-	if lpa.CertificateProvider == emptyCertificateProvider {
-		return []shared.FieldError{{Source: "/type", Detail: "certificate provider not present on LPA"}}
-	}
-
 	if lpa.CertificateProvider.SignedAt != nil && !lpa.CertificateProvider.SignedAt.IsZero() {
 		return []shared.FieldError{{Source: "/type", Detail: "certificate provider cannot opt out after providing certificate"}}
 	}
 
-	lpa.CertificateProviderNotRelatedConfirmedAt = nil
-	lpa.CertificateProvider = shared.CertificateProvider{}
+	lpa.Status = shared.LpaStatusCannotRegister
 
 	return nil
 }

--- a/lambda/update/certificate_provider_opt_out.go
+++ b/lambda/update/certificate_provider_opt_out.go
@@ -14,6 +14,7 @@ func (c CertificateProviderOptOut) Apply(lpa *shared.Lpa) []shared.FieldError {
 		return []shared.FieldError{{Source: "/type", Detail: "certificate provider cannot opt out after providing certificate"}}
 	}
 
+	lpa.CertificateProviderNotRelatedConfirmedAt = nil
 	lpa.CertificateProvider = shared.CertificateProvider{}
 
 	return nil

--- a/lambda/update/certificate_provider_opt_out_test.go
+++ b/lambda/update/certificate_provider_opt_out_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCertificateProviderOptOutApply(t *testing.T) {
+	lpa := &shared.Lpa{LpaInit: shared.LpaInit{CertificateProvider: shared.CertificateProvider{Email: "a@example"}}}
+	c := CertificateProviderOptOut{}
+
+	errors := c.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, shared.CertificateProvider{}, lpa.CertificateProvider)
+}
+
+func TestCertificateProviderOptOutApplyWhenNoCertificateProvider(t *testing.T) {
+	lpa := &shared.Lpa{LpaInit: shared.LpaInit{
+		CertificateProvider: shared.CertificateProvider{}},
+	}
+
+	errors := CertificateProviderOptOut{}.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "certificate provider not present on LPA"}})
+}
+
+func TestCertificateProviderOptOutApplyWhenCertificateProvided(t *testing.T) {
+	now := time.Now()
+	certificateProvider := shared.CertificateProvider{Email: "a@example", SignedAt: &now}
+	lpa := &shared.Lpa{LpaInit: shared.LpaInit{
+		CertificateProvider: certificateProvider},
+	}
+
+	errors := CertificateProviderOptOut{}.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "certificate provider cannot opt out after providing certificate"}})
+	assert.Equal(t, certificateProvider, lpa.CertificateProvider)
+}

--- a/lambda/update/certificate_provider_opt_out_test.go
+++ b/lambda/update/certificate_provider_opt_out_test.go
@@ -13,8 +13,10 @@ func TestCertificateProviderOptOutApply(t *testing.T) {
 	c := CertificateProviderOptOut{}
 
 	errors := c.Apply(lpa)
+
 	assert.Empty(t, errors)
 	assert.Equal(t, shared.CertificateProvider{}, lpa.CertificateProvider)
+	assert.Nil(t, lpa.CertificateProviderNotRelatedConfirmedAt)
 }
 
 func TestCertificateProviderOptOutApplyWhenNoCertificateProvider(t *testing.T) {
@@ -23,6 +25,7 @@ func TestCertificateProviderOptOutApplyWhenNoCertificateProvider(t *testing.T) {
 	}
 
 	errors := CertificateProviderOptOut{}.Apply(lpa)
+
 	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "certificate provider not present on LPA"}})
 }
 
@@ -34,6 +37,7 @@ func TestCertificateProviderOptOutApplyWhenCertificateProvided(t *testing.T) {
 	}
 
 	errors := CertificateProviderOptOut{}.Apply(lpa)
+
 	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "certificate provider cannot opt out after providing certificate"}})
 	assert.Equal(t, certificateProvider, lpa.CertificateProvider)
 }

--- a/lambda/update/certificate_provider_opt_out_test.go
+++ b/lambda/update/certificate_provider_opt_out_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -9,24 +10,13 @@ import (
 )
 
 func TestCertificateProviderOptOutApply(t *testing.T) {
-	lpa := &shared.Lpa{LpaInit: shared.LpaInit{CertificateProvider: shared.CertificateProvider{Email: "a@example"}}}
+	lpa := &shared.Lpa{Status: shared.LpaStatusProcessing}
 	c := CertificateProviderOptOut{}
 
 	errors := c.Apply(lpa)
 
 	assert.Empty(t, errors)
-	assert.Equal(t, shared.CertificateProvider{}, lpa.CertificateProvider)
-	assert.Nil(t, lpa.CertificateProviderNotRelatedConfirmedAt)
-}
-
-func TestCertificateProviderOptOutApplyWhenNoCertificateProvider(t *testing.T) {
-	lpa := &shared.Lpa{LpaInit: shared.LpaInit{
-		CertificateProvider: shared.CertificateProvider{}},
-	}
-
-	errors := CertificateProviderOptOut{}.Apply(lpa)
-
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "certificate provider not present on LPA"}})
+	assert.Equal(t, shared.LpaStatusCannotRegister, lpa.Status)
 }
 
 func TestCertificateProviderOptOutApplyWhenCertificateProvided(t *testing.T) {
@@ -40,4 +30,41 @@ func TestCertificateProviderOptOutApplyWhenCertificateProvided(t *testing.T) {
 
 	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "certificate provider cannot opt out after providing certificate"}})
 	assert.Equal(t, certificateProvider, lpa.CertificateProvider)
+}
+
+func TestValidateUpdateCertificateProviderOptOut(t *testing.T) {
+	testcases := map[string]struct {
+		update shared.Update
+		lpa    *shared.Lpa
+		errors []shared.FieldError
+	}{
+		"valid": {
+			update: shared.Update{
+				Type:    "CERTIFICATE_PROVIDER_OPT_OUT",
+				Changes: []shared.Change{},
+			},
+		},
+		"with changes": {
+			update: shared.Update{
+				Type: "CERTIFICATE_PROVIDER_OPT_OUT",
+				Changes: []shared.Change{
+					{
+						Key: "/something/someValue",
+						New: json.RawMessage(`"not expected"`),
+						Old: jsonNull,
+					},
+				},
+			},
+			errors: []shared.FieldError{
+				{Source: "/changes", Detail: "expected empty"},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			_, errors := validateUpdate(tc.update, &shared.Lpa{})
+			assert.ElementsMatch(t, tc.errors, errors)
+		})
+	}
 }

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -10,16 +10,18 @@ type Applyable interface {
 
 func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.FieldError) {
 	switch update.Type {
-	case "CERTIFICATE_PROVIDER_SIGN":
-		return validateCertificateProviderSign(update.Changes, lpa)
 	case "ATTORNEY_SIGN":
 		return validateAttorneySign(update.Changes, lpa)
-	case "TRUST_CORPORATION_SIGN":
-		return validateTrustCorporationSign(update.Changes, lpa)
+	case "CERTIFICATE_PROVIDER_OPT_OUT":
+		return validateCertificateProviderOptOut(update.Changes)
+	case "CERTIFICATE_PROVIDER_SIGN":
+		return validateCertificateProviderSign(update.Changes, lpa)
 	case "PERFECT":
 		return validatePerfect(update.Changes)
 	case "REGISTER":
 		return validateRegister(update.Changes)
+	case "TRUST_CORPORATION_SIGN":
+		return validateTrustCorporationSign(update.Changes, lpa)
 	default:
 		return nil, []shared.FieldError{{Source: "/type", Detail: "invalid value"}}
 	}


### PR DESCRIPTION
Partially fixes [MLPAB-1269](https://opgtransform.atlassian.net/browse/MLPAB-1269). 



[MLPAB-1269]: https://opgtransform.atlassian.net/browse/MLPAB-1269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ