### PR TITLE
Don't enforce validation on paper-channel LPAs

### DIFF
--- a/fixtures/static/js/json-schema-editor.mjs
+++ b/fixtures/static/js/json-schema-editor.mjs
@@ -61,12 +61,15 @@ export class JsonSchemaEditor {
 
     $container.addEventListener("input", (e) => {
       if (
-        e.target instanceof HTMLInputElement ||
-        e.target instanceof HTMLSelectElement
+        (e.target instanceof HTMLInputElement ||
+          e.target instanceof HTMLSelectElement) &&
+        e.target.name
       ) {
         const value = JSON.parse(this.$module.value);
         jsonSet(value, e.target.name, e.target.value);
         this.$module.value = JSON.stringify(value);
+
+        if (e.target.name === "/channel") this.build();
       }
     });
 

--- a/internal/shared/date.go
+++ b/internal/shared/date.go
@@ -31,6 +31,10 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 }
 
 func (d *Date) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
 	var err error
 	d.t, err = time.Parse(time.DateOnly, string(data))
 	return err

--- a/internal/shared/date_test.go
+++ b/internal/shared/date_test.go
@@ -92,10 +92,11 @@ func TestDateDynamoDB(t *testing.T) {
 			av := &types.AttributeValueMemberS{Value: tc.dynamo}
 
 			var unmarshal Date
-			attributevalue.Unmarshal(av, &unmarshal)
+			assert.Nil(t, attributevalue.Unmarshal(av, &unmarshal))
 			assert.Equal(t, tc.date, unmarshal)
 
-			marshal, _ := attributevalue.Marshal(unmarshal)
+			marshal, err := attributevalue.Marshal(unmarshal)
+			assert.Nil(t, err)
 			assert.Equal(t, av, marshal)
 		})
 	}

--- a/lambda/create/main.go
+++ b/lambda/create/main.go
@@ -89,12 +89,16 @@ func (l *Lambda) HandleEvent(ctx context.Context, req events.APIGatewayProxyRequ
 
 	// validation
 	if errs := Validate(input); len(errs) > 0 {
-		problem := shared.ProblemInvalidRequest
-		problem.Errors = errs
+		if input.Channel == shared.ChannelPaper {
+			l.logger.Info("encountered validation errors in lpa", slog.Any("uid", uid))
+		} else {
+			problem := shared.ProblemInvalidRequest
+			problem.Errors = errs
 
-		return problem.Respond()
+			return problem.Respond()
+		}
 	}
-	
+
 	data := shared.Lpa{LpaInit: input}
 	data.Uid = uid
 	data.Status = shared.LpaStatusProcessing


### PR DESCRIPTION
We can't kick back a 400 response to the scanners because they can't change what they send, so log and accept the validation errors.

Plus fix an existing bug with unmarshalling empty dates.

For CTC-146 #patch