### PR TITLE
Support image-based R&C for Paper LPAs

### DIFF
--- a/docs/schemas/2024-10/donor-details.json
+++ b/docs/schemas/2024-10/donor-details.json
@@ -135,12 +135,32 @@
       "type": "string",
       "enum": ["option-a", "option-b"]
     },
-    "restrictionsAndConditions": {
-      "type": "string"
-    },
     "signedAt": {
       "type": "string",
       "format": "date-time"
+    }
+  },
+  "if": {
+    "required": ["channel"],
+    "properties": {
+      "channel": { "const": "online" }
+    }
+  },
+  "then": {
+    "properties": {
+      "restrictionsAndConditions": {
+        "type": "string"
+      }
+    }
+  },
+  "else": {
+    "properties": {
+      "restrictionsAndConditionsImages": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/File"
+        }
+      }
     }
   },
   "additionalProperties": false,
@@ -234,16 +254,16 @@
         "channel": {
           "type": "string",
           "enum": ["paper", "online"]
-        },
-        "if": {
-          "required": ["channel"],
-          "properties": {
-            "channel": { "const": "online" }
-          }
-        },
-        "then": {
-          "required": ["email"]
         }
+      },
+      "if": {
+        "required": ["channel"],
+        "properties": {
+          "channel": { "const": "online" }
+        }
+      },
+      "then": {
+        "required": ["email"]
       }
     },
     "TrustCorporation": {
@@ -274,16 +294,16 @@
         "channel": {
           "type": "string",
           "enum": ["paper", "online"]
-        },
-        "if": {
-          "required": ["channel"],
-          "properties": {
-            "channel": { "const": "online" }
-          }
-        },
-        "then": {
-          "required": ["email"]
         }
+      },
+      "if": {
+        "required": ["channel"],
+        "properties": {
+          "channel": { "const": "online" }
+        }
+      },
+      "then": {
+        "required": ["email"]
       }
     },
     "PersonToNotify": {
@@ -293,6 +313,18 @@
         }
       ],
       "type": "object"
+    },
+    "File": {
+      "type": "object",
+      "required": ["filename", "data"],
+      "properties": {
+        "filename": {
+          "type": "string"
+        },
+        "data": {
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/internal/objectstore/client.go
+++ b/internal/objectstore/client.go
@@ -65,7 +65,11 @@ func (c *S3Client) UploadFile(ctx context.Context, file shared.FileUpload, path 
 	}
 
 	hash := sha256.New()
-	hash.Write(imgData)
+	_, err = hash.Write(imgData)
+
+	if err != nil {
+		return shared.File{}, err
+	}
 
 	return shared.File{
 		Path: path,

--- a/internal/objectstore/client.go
+++ b/internal/objectstore/client.go
@@ -3,11 +3,15 @@ package objectstore
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 )
 
 type awsS3Client interface {
@@ -36,6 +40,38 @@ func (c *S3Client) Put(ctx context.Context, objectKey string, obj any) error {
 	)
 
 	return err
+}
+
+func (c *S3Client) UploadFile(ctx context.Context, file shared.FileUpload, path string) (shared.File, error) {
+	var imgData []byte
+	var err error
+
+	if imgData, err = base64.StdEncoding.DecodeString(file.Data); err != nil {
+		return shared.File{}, err
+	}
+
+	_, err = c.awsClient.PutObject(
+		ctx,
+		&s3.PutObjectInput{
+			Bucket:               aws.String(c.bucketName),
+			Key:                  aws.String(path),
+			Body:                 bytes.NewReader(imgData),
+			ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+		},
+	)
+
+	if err != nil {
+		return shared.File{}, err
+	}
+
+	hash := sha256.New()
+	hash.Write(imgData)
+
+	return shared.File{
+		Path: path,
+		Hash: hex.EncodeToString(hash.Sum(nil)),
+	}, nil
+
 }
 
 func NewS3Client(awsConfig aws.Config, bucketName string) *S3Client {

--- a/internal/objectstore/client_test.go
+++ b/internal/objectstore/client_test.go
@@ -1,10 +1,15 @@
 package objectstore
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -30,5 +35,77 @@ func TestPut(t *testing.T) {
 	err := c.Put(context.Background(), "anobject", struct{ ID int }{ID: 1})
 
 	assert.Equal(t, nil, err)
+	client.AssertExpectations(t)
+}
+
+func TestUploadFile(t *testing.T) {
+	upload := shared.FileUpload{
+		Filename: "myfile.txt",
+		Data:     "Q29udGVudHMgb2YgbXkgZmlsZQ==",
+	}
+
+	client := mockAwsClient{}
+	client.On("PutObject", mock.Anything, &s3.PutObjectInput{
+		Bucket:               aws.String("bucket1"),
+		Key:                  aws.String("dir/myfile.txt"),
+		Body:                 bytes.NewReader([]byte("Contents of my file")),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+	}).Return(&s3.PutObjectOutput{}, nil)
+
+	c := S3Client{
+		bucketName: "bucket1",
+		awsClient:  &client,
+	}
+
+	file, err := c.UploadFile(context.Background(), upload, "dir/myfile.txt")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "dir/myfile.txt", file.Path)
+	assert.Equal(t, "7ac4f2b48096ac5f4600a0775563d0f2b3369a3ea00d1fa813f45c18620dba28", file.Hash)
+	client.AssertExpectations(t)
+}
+
+func TestUploadFileDecodingError(t *testing.T) {
+	upload := shared.FileUpload{
+		Filename: "myfile.txt",
+		Data:     "This isn't base 64",
+	}
+
+	c := S3Client{
+		bucketName: "bucket1",
+		awsClient:  &mockAwsClient{},
+	}
+
+	file, err := c.UploadFile(context.Background(), upload, "dir/myfile.txt")
+
+	assert.Equal(t, file, shared.File{})
+	assert.Contains(t, err.Error(), "illegal base64 data")
+}
+
+func TestUploadFileS3Error(t *testing.T) {
+	upload := shared.FileUpload{
+		Filename: "myfile.txt",
+		Data:     "Q29udGVudHMgb2YgbXkgZmlsZQ==",
+	}
+
+	expectedErr := errors.New("could not save object")
+
+	client := mockAwsClient{}
+	client.On("PutObject", mock.Anything, &s3.PutObjectInput{
+		Bucket:               aws.String("bucket1"),
+		Key:                  aws.String("dir/myfile.txt"),
+		Body:                 bytes.NewReader([]byte("Contents of my file")),
+		ServerSideEncryption: types.ServerSideEncryptionAwsKms,
+	}).Return(&s3.PutObjectOutput{}, expectedErr)
+
+	c := S3Client{
+		bucketName: "bucket1",
+		awsClient:  &client,
+	}
+
+	file, err := c.UploadFile(context.Background(), upload, "dir/myfile.txt")
+
+	assert.Equal(t, file, shared.File{})
+	assert.Equal(t, expectedErr, err)
 	client.AssertExpectations(t)
 }

--- a/internal/shared/image.go
+++ b/internal/shared/image.go
@@ -1,0 +1,11 @@
+package shared
+
+type File struct {
+	Path string `json:"path"`
+	Hash string `json:"hash"`
+}
+
+type FileUpload struct {
+	Filename string `json:"filename"`
+	Data     string `json:"data"`
+}

--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -21,16 +21,18 @@ type LpaInit struct {
 	WhenTheLpaCanBeUsed                         CanUse                  `json:"whenTheLpaCanBeUsed,omitempty"`
 	LifeSustainingTreatmentOption               LifeSustainingTreatment `json:"lifeSustainingTreatmentOption,omitempty"`
 	RestrictionsAndConditions                   string                  `json:"restrictionsAndConditions,omitempty"`
+	RestrictionsAndConditionsImages             []FileUpload            `json:"restrictionsAndConditionsImages,omitempty"`
 	SignedAt                                    time.Time               `json:"signedAt"`
 	CertificateProviderNotRelatedConfirmedAt    *time.Time              `json:"certificateProviderNotRelatedConfirmedAt,omitempty"`
 }
 
 type Lpa struct {
 	LpaInit
-	Uid              string     `json:"uid"`
-	Status           LpaStatus  `json:"status"`
-	RegistrationDate *time.Time `json:"registrationDate,omitempty"`
-	UpdatedAt        time.Time  `json:"updatedAt"`
+	Uid                             string     `json:"uid"`
+	Status                          LpaStatus  `json:"status"`
+	RegistrationDate                *time.Time `json:"registrationDate,omitempty"`
+	UpdatedAt                       time.Time  `json:"updatedAt"`
+	RestrictionsAndConditionsImages []File     `json:"restrictionsAndConditionsImages,omitempty"`
 }
 
 type LpaType string


### PR DESCRIPTION
- Alter schema to change fields available based on form channel
- Add `FileUpload` and `File` struct types
  - `FileUpload` is used in submissions, `File` is used to pass back
- Add `S3Client.UploadFile` to copy base64-encoded files into S3
- On submission of Paper LPAs, store `FileUpload` objects in S3 and return a reference to them in `File`
- Update the fixtures UI to support uploads

For CTC-146 #minor