### PR TITLE
Upgrade requests to 2.32.0 (fixes dependabot security issue)

### DIFF
--- a/fixtures/requirements.txt
+++ b/fixtures/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.0.3
-requests==2.31.0
+requests==2.32.0
 Jinja2==3.1.4
 jsonschema==4.22.0
 boto3==1.34.103


### PR DESCRIPTION
This fixes a dependabot security issue.

I ended up doing this manually due to an inexplicable error coming from the PR generated by dependabot.