### PR TITLE
Move AWS endpoint configuration to services

### DIFF
--- a/internal/ddb/client.go
+++ b/internal/ddb/client.go
@@ -16,9 +16,13 @@ type Client struct {
 	changesTableName string
 }
 
-func New(cfg aws.Config, tableName, changesTableName string) *Client {
+func New(cfg aws.Config, endpointURL string, tableName, changesTableName string) *Client {
 	return &Client{
-		ddb:              dynamodb.NewFromConfig(cfg),
+		ddb: dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+			if endpointURL != "" {
+				o.BaseEndpoint = aws.String(endpointURL)
+			}
+		}),
 		tableName:        tableName,
 		changesTableName: changesTableName,
 	}

--- a/internal/event/client.go
+++ b/internal/event/client.go
@@ -20,9 +20,13 @@ type Client struct {
 	svc          EventBridgeClient
 }
 
-func NewClient(cfg aws.Config, eventBusName string) *Client {
+func NewClient(cfg aws.Config, endpointURL string, eventBusName string) *Client {
 	return &Client{
-		svc:          eventbridge.NewFromConfig(cfg),
+		svc: eventbridge.NewFromConfig(cfg, func(o *eventbridge.Options) {
+			if endpointURL != "" {
+				o.BaseEndpoint = aws.String(endpointURL)
+			}
+		}),
 		eventBusName: eventBusName,
 	}
 }

--- a/internal/shared/jwt.go
+++ b/internal/shared/jwt.go
@@ -83,8 +83,12 @@ type logger interface {
 	Error(string, ...any)
 }
 
-func NewJWTVerifier(cfg aws.Config, logger logger) JWTVerifier {
-	client := secretsmanager.NewFromConfig(cfg)
+func NewJWTVerifier(cfg aws.Config, endpointURL string, logger logger) JWTVerifier {
+	client := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
+		if endpointURL != "" {
+			o.BaseEndpoint = aws.String(endpointURL)
+		}
+	})
 
 	secretKey, err := client.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
 		SecretId: aws.String(os.Getenv("JWT_SECRET_KEY_ID")),

--- a/lambda/create/main.go
+++ b/lambda/create/main.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/ddb"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/event"
@@ -157,33 +156,26 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
+	cfg, err := config.LoadDefaultConfig(ctx)
 
-		return nil
-	})
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
 	}
 
 	l := &Lambda{
-		eventClient: event.NewClient(cfg, os.Getenv("EVENT_BUS_NAME")),
+		eventClient: event.NewClient(cfg, endpointURL, os.Getenv("EVENT_BUS_NAME")),
 		store: ddb.New(
 			cfg,
+			endpointURL,
 			os.Getenv("DDB_TABLE_NAME_DEEDS"),
 			os.Getenv("DDB_TABLE_NAME_CHANGES"),
 		),
 		staticLpaStorage: objectstore.NewS3Client(
 			cfg,
+			endpointURL,
 			os.Getenv("S3_BUCKET_NAME_ORIGINAL"),
 		),
-		verifier: shared.NewJWTVerifier(cfg, logger),
+		verifier: shared.NewJWTVerifier(cfg, endpointURL, logger),
 		logger:   logger,
 	}
 

--- a/lambda/getlist/main.go
+++ b/lambda/getlist/main.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/ddb"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
@@ -88,17 +87,8 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
+	cfg, err := config.LoadDefaultConfig(ctx)
 
-		return nil
-	})
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
 	}
@@ -106,10 +96,11 @@ func main() {
 	l := &Lambda{
 		store: ddb.New(
 			cfg,
+			endpointURL,
 			os.Getenv("DDB_TABLE_NAME_DEEDS"),
 			os.Getenv("DDB_TABLE_NAME_CHANGES"),
 		),
-		verifier: shared.NewJWTVerifier(cfg, logger),
+		verifier: shared.NewJWTVerifier(cfg, endpointURL, logger),
 		logger:   logger,
 	}
 

--- a/lambda/update/main.go
+++ b/lambda/update/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/ddb"
@@ -128,29 +127,21 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
+	cfg, err := config.LoadDefaultConfig(ctx)
 
-		return nil
-	})
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
 	}
 
 	l := &Lambda{
-		eventClient: event.NewClient(cfg, os.Getenv("EVENT_BUS_NAME")),
+		eventClient: event.NewClient(cfg, endpointURL, os.Getenv("EVENT_BUS_NAME")),
 		store: ddb.New(
 			cfg,
+			endpointURL,
 			os.Getenv("DDB_TABLE_NAME_DEEDS"),
 			os.Getenv("DDB_TABLE_NAME_CHANGES"),
 		),
-		verifier: shared.NewJWTVerifier(cfg, logger),
+		verifier: shared.NewJWTVerifier(cfg, endpointURL, logger),
 		logger:   logger,
 	}
 


### PR DESCRIPTION
aws-sdk-go-v2 has deprecated setting endpoint configuration at SDK-level, it now much be configured for each service.

#patch