### PR TITLE
Migrate AWS endpoint configuration

### DIFF
--- a/internal/objectstore/client.go
+++ b/internal/objectstore/client.go
@@ -79,7 +79,9 @@ func (c *S3Client) UploadFile(ctx context.Context, file shared.FileUpload, path 
 }
 
 func NewS3Client(awsConfig aws.Config, bucketName string) *S3Client {
-	awsClient := s3.NewFromConfig(awsConfig)
+	awsClient := s3.NewFromConfig(awsConfig, func(o *s3.Options) {
+		o.UsePathStyle = true
+	})
 
 	return &S3Client{
 		bucketName: bucketName,

--- a/lambda/create/main.go
+++ b/lambda/create/main.go
@@ -157,19 +157,13 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
-
-		return nil
-	})
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
+	}
+
+	if endpointURL != "" {
+		cfg.BaseEndpoint = aws.String(endpointURL)
 	}
 
 	l := &Lambda{

--- a/lambda/get/main.go
+++ b/lambda/get/main.go
@@ -83,19 +83,13 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
-
-		return nil
-	})
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
+	}
+
+	if endpointURL != "" {
+		cfg.BaseEndpoint = aws.String(endpointURL)
 	}
 
 	l := &Lambda{

--- a/lambda/getlist/main.go
+++ b/lambda/getlist/main.go
@@ -88,19 +88,13 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
-
-		return nil
-	})
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
+	}
+
+	if endpointURL != "" {
+		cfg.BaseEndpoint = aws.String(endpointURL)
 	}
 
 	l := &Lambda{

--- a/lambda/update/main.go
+++ b/lambda/update/main.go
@@ -128,19 +128,13 @@ func main() {
 	// set endpoint to "" outside dev to use default AWS resolver
 	endpointURL := os.Getenv("AWS_BASE_URL")
 
-	cfg, err := config.LoadDefaultConfig(ctx, func(o *config.LoadOptions) error {
-		if endpointURL != "" {
-			o.EndpointResolverWithOptions = aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: endpointURL, HostnameImmutable: true}, nil
-				},
-			)
-		}
-
-		return nil
-	})
+	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		logger.Error("failed to load aws config", slog.Any("err", err))
+	}
+
+	if endpointURL != "" {
+		cfg.BaseEndpoint = aws.String(endpointURL)
 	}
 
 	l := &Lambda{


### PR DESCRIPTION
V1 endpoint resovlers are being deprecated, so instead set a BaseEndpoint in config and use path style URLs.

#patch