### PR TITLE
Add opg-modernising-lpa-team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-*       @ministryofjustice/sirius
-*       @ministryofjustice/opg-modernising-lpa-team
+*       @ministryofjustice/sirius @ministryofjustice/opg-modernising-lpa-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @ministryofjustice/sirius
+*       @ministryofjustice/opg-modernising-lpa-team


### PR DESCRIPTION
It's a shared repo so both teams should be owners (though in reality most people are in both teams anyway).

#patch