### PR TITLE
MLPAB-2044 Add validation for donor identity check with initial LPA

### DIFF
--- a/docs/certificate-provider-confirm-identity.json
+++ b/docs/certificate-provider-confirm-identity.json
@@ -10,11 +10,6 @@
             "key": "/certificateProvider/identityCheck/type",
             "new": "one-login",
             "old": null
-        },
-        {
-            "key": "/certificateProvider/identityCheck/reference",
-            "new": "1234567890",
-            "old": null
         }
     ]
 }

--- a/docs/donor-confirm-identity.json
+++ b/docs/donor-confirm-identity.json
@@ -10,11 +10,6 @@
             "key": "/donor/identityCheck/type",
             "new": "one-login",
             "old": null
-        },
-        {
-            "key": "/donor/identityCheck/reference",
-            "new": "1234567890",
-            "old": null
         }
     ]
 }

--- a/docs/schemas/2024-10/donor-details.json
+++ b/docs/schemas/2024-10/donor-details.json
@@ -44,6 +44,10 @@
         "contactLanguagePreference": {
           "type": "string",
           "enum": ["en", "cy"]
+        },
+        "identityCheck": {
+          "allOf": [{"$ref": "#/$defs/IdentityCheck"}],
+          "type": "object",
         }
       }
     },
@@ -89,6 +93,10 @@
         "channel": {
           "type": "string",
           "enum": ["paper", "online"]
+        },
+        "identityCheck": {
+          "allOf": [{"$ref": "#/$defs/IdentityCheck"}],
+          "type": "object",
         }
       }
     },
@@ -322,6 +330,23 @@
           "type": "string"
         },
         "data": {
+          "type": "string"
+        }
+      }
+    },
+    "IdentityCheck": {
+      "type": "object",
+      "required": ["checkedAt", "type"],
+      "properties": {
+        "checkedAt": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["one-login", "opg-paper-id"]
+        },
+        "reference": {
           "type": "string"
         }
       }

--- a/docs/schemas/2024-10/donor-details.json
+++ b/docs/schemas/2024-10/donor-details.json
@@ -345,9 +345,6 @@
         "type": {
           "type": "string",
           "enum": ["one-login", "opg-paper-id"]
-        },
-        "reference": {
-          "type": "string"
         }
       }
     }

--- a/internal/shared/person.go
+++ b/internal/shared/person.go
@@ -105,7 +105,6 @@ type PersonToNotify struct {
 
 type IdentityCheck struct {
 	CheckedAt time.Time         `json:"checkedAt"`
-	Reference string            `json:"reference"`
 	Type      IdentityCheckType `json:"type"`
 }
 

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -35,6 +35,14 @@ func If(ok bool, e []shared.FieldError) []shared.FieldError {
 	return IfElse(ok, e, nil)
 }
 
+func IfFunc(ok bool, fn func() []shared.FieldError) []shared.FieldError {
+	if ok {
+		return fn()
+	}
+
+	return nil
+}
+
 func Required(source string, value string) []shared.FieldError {
 	return If(value == "", []shared.FieldError{{Source: source, Detail: "field is required"}})
 }

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -19,6 +19,11 @@ func Validate(lpa shared.LpaInit) []shared.FieldError {
 		validate.Date("/donor/dateOfBirth", lpa.Donor.DateOfBirth),
 		validate.Address("/donor/address", lpa.Donor.Address),
 		validate.IsValid("/donor/contactLanguagePreference", lpa.Donor.ContactLanguagePreference),
+		validate.IfFunc(lpa.Donor.IdentityCheck != nil, func() []shared.FieldError {
+			return validate.All(
+				validate.Time("/donor/identityCheck/checkedAt", lpa.Donor.IdentityCheck.CheckedAt),
+				validate.IsValid("/donor/identityCheck/type", lpa.Donor.IdentityCheck.Type))
+		}),
 		validate.UUID("/certificateProvider/uid", lpa.CertificateProvider.UID),
 		validate.Required("/certificateProvider/firstNames", lpa.CertificateProvider.FirstNames),
 		validate.Required("/certificateProvider/lastName", lpa.CertificateProvider.LastName),

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -482,6 +482,18 @@ func TestValidateLpaInvalid(t *testing.T) {
 				{Source: "/trustCorporations/0/email", Detail: "field must not be provided"},
 			},
 		},
+		"incorrect identity check": {
+			lpa: func() shared.LpaInit {
+				lpa := makeLpaWithDonorAndActors()
+				lpa.Donor.IdentityCheck = &shared.IdentityCheck{Type: "what"}
+
+				return lpa
+			},
+			expectedErrors: []shared.FieldError{
+				{Source: "/donor/identityCheck/checkedAt", Detail: "field is required"},
+				{Source: "/donor/identityCheck/type", Detail: "invalid value"},
+			},
+		},
 	}
 
 	for name, tc := range testcases {

--- a/lambda/update/confirm_identity.go
+++ b/lambda/update/confirm_identity.go
@@ -46,7 +46,6 @@ func validateConfirmIdentity(prefix string, actor idccActor, ic *shared.Identity
 				Field("/checkedAt", &ic.CheckedAt, parse.Validate(func() []shared.FieldError {
 					return validate.Time("", ic.CheckedAt)
 				})).
-				Field("/reference", &ic.Reference, parse.Optional()).
 				Consumed()
 		}).
 		Consumed()


### PR DESCRIPTION
To avoid having modernise filled with 

```
SendLpa(...)
SendDonorConfirmIdentity(...)
```

