### PR TITLE
Create a replicated secret in management account for the jwt-key

### DIFF
--- a/terraform/account/data_sources.tf
+++ b/terraform/account/data_sources.tf
@@ -1,0 +1,11 @@
+data "aws_default_tags" "default" {
+  provider = aws.eu_west_1
+}
+
+data "aws_region" "eu_west_1" {
+  provider = aws.eu_west_1
+}
+
+data "aws_region" "eu_west_2" {
+  provider = aws.eu_west_2
+}

--- a/terraform/account/secrets.tf
+++ b/terraform/account/secrets.tf
@@ -1,0 +1,8 @@
+resource "aws_secretsmanager_secret" "jwt_key" {
+  name        = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
+  description = "JWT key for ${data.aws_default_tags.default.tags.application} in ${data.aws_default_tags.default.tags.account}, for use with Make and Register, and Use a LPA"
+  replica {
+    region = data.aws_region.eu_west_2.name
+  }
+  provider = aws.management_eu_west_1
+}


### PR DESCRIPTION
# Purpose

This secret value needs to be accessed by MLPA and UaL. In this PR, I will create a new secret to hold a copy of the secret.

Fixes MLPAB-2189

## Approach

- Create a secret called `opg-data-lpa-store/<account-name>/jwt-key` in the management account
- Configure replication for the secret to eu-west-2
- Use data sources for tags and region to make refactoring easier