### PR TITLE
Simplify identity check schema

### DIFF
--- a/docs/schemas/2024-10/donor-details.json
+++ b/docs/schemas/2024-10/donor-details.json
@@ -46,8 +46,7 @@
           "enum": ["en", "cy"]
         },
         "identityCheck": {
-          "allOf": [{"$ref": "#/$defs/IdentityCheck"}],
-          "type": "object"
+          "$ref": "#/$defs/IdentityCheck"
         }
       }
     },


### PR DESCRIPTION
Rather than saying it must be `#/$defs/IdentityCheck` and an object, just require it to be `#/$defs/IdentityCheck`.

This also fixes the fixtures editor JS.

#patch