### PR TITLE
MLPAB-2237 - Refactor IAM policies ahead of move to shared secret usage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       DDB_TABLE_NAME_CHANGES: changes
       S3_BUCKET_NAME_ORIGINAL: opg-lpa-store-static-eu-west-1
       EVENT_BUS_NAME: local-main
-      JWT_SECRET_KEY_ID: local/jwt-key
+      JWT_SECRET_KEY_ARN: local/jwt-key
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"
     entrypoint: /aws-lambda/aws-lambda-rie /var/task/main
@@ -41,7 +41,7 @@ services:
       DDB_TABLE_NAME_DEEDS: deeds
       DDB_TABLE_NAME_CHANGES: changes
       EVENT_BUS_NAME: local-main
-      JWT_SECRET_KEY_ID: local/jwt-key
+      JWT_SECRET_KEY_ARN: local/jwt-key
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"
     entrypoint: /aws-lambda/aws-lambda-rie /var/task/main
@@ -64,7 +64,7 @@ services:
       DDB_TABLE_NAME_DEEDS: deeds
       DDB_TABLE_NAME_CHANGES: changes
       EVENT_BUS_NAME: local-main
-      JWT_SECRET_KEY_ID: local/jwt-key
+      JWT_SECRET_KEY_ARN: local/jwt-key
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"
     entrypoint: /aws-lambda/aws-lambda-rie /var/task/main
@@ -87,7 +87,7 @@ services:
       DDB_TABLE_NAME_DEEDS: deeds
       DDB_TABLE_NAME_CHANGES: changes
       EVENT_BUS_NAME: local-main
-      JWT_SECRET_KEY_ID: local/jwt-key
+      JWT_SECRET_KEY_ARN: local/jwt-key
     volumes:
       - "./lambda/.aws-lambda-rie:/aws-lambda"
     entrypoint: /aws-lambda/aws-lambda-rie /var/task/main

--- a/internal/shared/jwt.go
+++ b/internal/shared/jwt.go
@@ -89,7 +89,7 @@ func NewJWTVerifier(cfg aws.Config, logger logger) JWTVerifier {
 	client := secretsmanager.NewFromConfig(cfg)
 
 	secretKey, err := client.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
-		SecretId: aws.String(os.Getenv("JWT_SECRET_KEY_ID")),
+		SecretId: aws.String(os.Getenv("JWT_SECRET_KEY_ARN")),
 	})
 
 	if err != nil {

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -1,3 +1,17 @@
+data "aws_region" "current" {
+  provider = aws.region
+}
+
+data "aws_caller_identity" "current" {
+  provider = aws.region
+}
+
+# we could use this data source instead of using an input variable for the account name
+# data "aws_default_tags" "current" {
+#   provider = aws.region
+# }
+
+
 data "aws_vpc" "main" {
   filter {
     name   = "tag:name"
@@ -32,5 +46,10 @@ data "aws_subnets" "application" {
     values = ["application-*"]
   }
 
+  provider = aws.region
+}
+
+data "aws_secretsmanager_secret" "jwt_secret_key" {
+  name     = "${var.account_name}/jwt-key"
   provider = aws.region
 }

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -11,7 +11,6 @@ data "aws_caller_identity" "current" {
 #   provider = aws.region
 # }
 
-
 data "aws_vpc" "main" {
   filter {
     name   = "tag:name"
@@ -49,6 +48,7 @@ data "aws_subnets" "application" {
   provider = aws.region
 }
 
+# this can be updated in future to reference the shared secret in the management account
 data "aws_secretsmanager_secret" "jwt_secret_key" {
   name     = "${var.account_name}/jwt-key"
   provider = aws.region

--- a/terraform/environment/region/iam.tf
+++ b/terraform/environment/region/iam.tf
@@ -68,3 +68,44 @@ data "aws_iam_policy_document" "lambda_s3_policy" {
     }
   }
 }
+
+resource "aws_iam_role_policy" "lambda_events_policy" {
+  for_each = local.functions
+  name     = "LambdaAllowEvents"
+  role     = module.lambda[each.key].iam_role.id
+  policy   = data.aws_iam_policy_document.lambda_events_policy.json
+  provider = aws.region
+}
+
+
+data "aws_iam_policy_document" "lambda_events_policy" {
+  statement {
+    sid       = "allowPutEvents"
+    effect    = "Allow"
+    resources = [var.event_bus.arn]
+    actions = [
+      "events:PutEvents"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_secrets_policy" {
+  for_each = local.functions
+  name     = "LambdaAllowSecrets"
+  role     = module.lambda[each.key].iam_role.id
+  policy   = data.aws_iam_policy_document.lambda_secrets_policy.json
+  provider = aws.region
+}
+
+
+data "aws_iam_policy_document" "lambda_secrets_policy" {
+  statement {
+    sid       = "allowReadJwtSecret"
+    effect    = "Allow"
+    resources = [data.aws_secretsmanager_secret.jwt_secret_key.arn]
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+  }
+}
+

--- a/terraform/environment/region/lambda.tf
+++ b/terraform/environment/region/lambda.tf
@@ -1,4 +1,5 @@
 locals {
+  # we could make maps of these functions to associate a specific iam role to specific functions
   functions = toset([
     "create",
     "get",
@@ -25,7 +26,7 @@ module "lambda" {
     DDB_TABLE_NAME_CHANGES  = var.dynamodb_name_changes
     EVENT_BUS_NAME          = var.event_bus.name
     S3_BUCKET_NAME_ORIGINAL = var.lpa_store_static_bucket.bucket
-    JWT_SECRET_KEY_ID       = data.aws_secretsmanager_secret.jwt_secret_key.arn
+    JWT_SECRET_KEY_ARN      = data.aws_secretsmanager_secret.jwt_secret_key.arn
   }
 
   providers = {

--- a/terraform/environment/region/lambda.tf
+++ b/terraform/environment/region/lambda.tf
@@ -25,7 +25,7 @@ module "lambda" {
     DDB_TABLE_NAME_CHANGES  = var.dynamodb_name_changes
     EVENT_BUS_NAME          = var.event_bus.name
     S3_BUCKET_NAME_ORIGINAL = var.lpa_store_static_bucket.bucket
-    JWT_SECRET_KEY_ID       = "${var.account_name}/jwt-key"
+    JWT_SECRET_KEY_ID       = data.aws_secretsmanager_secret.jwt_secret_key.arn
   }
 
   providers = {

--- a/terraform/environment/region/terraform.tf
+++ b/terraform/environment/region/terraform.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      version = ">= 5.8.0"
+      source  = "hashicorp/aws"
       configuration_aliases = [
         aws.global,
         aws.management,
@@ -11,16 +12,4 @@ terraform {
       ]
     }
   }
-}
-
-data "aws_region" "current" {
-  provider = aws.region
-}
-
-data "aws_caller_identity" "current" {
-  provider = aws.region
-}
-
-data "aws_default_tags" "current" {
-  provider = aws.region
 }

--- a/terraform/environment/region/variables.tf
+++ b/terraform/environment/region/variables.tf
@@ -51,6 +51,7 @@ variable "environment_name" {
 
 variable "event_bus" {
   description = "Event bus to send events to"
+  type        = any
 }
 
 variable "has_fixtures" {
@@ -61,8 +62,10 @@ variable "has_fixtures" {
 
 variable "lpa_store_static_bucket" {
   description = "LPA Store Static bucket object for the region"
+  type        = any
 }
 
 variable "lpa_store_static_bucket_kms_key" {
   description = "LPA Store Static bucket KMS Key object for the region"
+  type        = any
 }

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -45,28 +45,6 @@ data "aws_iam_policy_document" "lambda" {
       "logs:DescribeLogStreams"
     ]
   }
-
-  statement {
-    sid       = "allowPutEvents"
-    effect    = "Allow"
-    resources = [var.event_bus_arn]
-    actions = [
-      "events:PutEvents"
-    ]
-  }
-
-  statement {
-    sid       = "allowReadJwtSecret"
-    effect    = "Allow"
-    resources = [data.aws_secretsmanager_secret.jwt_secret_key.arn]
-    actions = [
-      "secretsmanager:GetSecretValue"
-    ]
-  }
-}
-
-data "aws_secretsmanager_secret" "jwt_secret_key" {
-  name = "${var.account_name}/jwt-key"
 }
 
 resource "aws_lambda_permission" "allow_lambda_execution_operator" {


### PR DESCRIPTION
# Purpose

Migrate toward using a shared secret for the JWT Key, making it easier for other services to access the key.

Fixes MLPAB-2237

## Approach

- refactor iam policies, so general actions (logging) are in module and purpose specific (accessing secrets, dynamodb access) are outside
- fix linter findings
- rename environment variable to `JWT_SECRET_KEY_ARN`

## Learning 
- https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/secretsmanager#GetSecretValueInput
- https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples.html#auth-and-access_examples_read

