### PR TITLE
MLPAB-2237 - remove policy and encryption

### DIFF
--- a/terraform/account/kms_key_jwt_secret.tf
+++ b/terraform/account/kms_key_jwt_secret.tf
@@ -58,28 +58,28 @@ data "aws_iam_policy_document" "jwt_kms" {
     }
   }
 
-  statement {
-    sid    = "Cross account access"
-    effect = "Allow"
-    resources = [
-      "arn:aws:kms:*:${data.aws_caller_identity.management.account_id}:key/*"
-    ]
-    actions = [
-      "kms:Decrypt",
-      "kms:GenerateDataKey*",
-      "kms:DescribeKey",
-    ]
+  # statement {
+  #   sid    = "Cross account access"
+  #   effect = "Allow"
+  #   resources = [
+  #     "arn:aws:kms:*:${data.aws_caller_identity.management.account_id}:key/*"
+  #   ]
+  #   actions = [
+  #     "kms:Decrypt",
+  #     "kms:GenerateDataKey*",
+  #     "kms:DescribeKey",
+  #   ]
 
-    principals {
-      type = "AWS"
-      identifiers = concat(
-        local.account.jwt_key_cross_account_access_roles,
-        [
-          # allow all roles in the lpa-store-lambda path in the current account
-          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/lpa-store-lambda/*",
-      ])
-    }
-  }
+  #   principals {
+  #     type = "AWS"
+  #     identifiers = concat(
+  #       local.account.jwt_key_cross_account_access_roles,
+  #       [
+  #         # allow all roles in the lpa-store-lambda path in the current account
+  #         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/lpa-store-lambda/*",
+  #     ])
+  #   }
+  # }
 
   statement {
     sid    = "Key Administrator"

--- a/terraform/account/secrets.tf
+++ b/terraform/account/secrets.tf
@@ -1,17 +1,18 @@
 resource "aws_secretsmanager_secret" "jwt_key" {
   name        = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
   description = "JWT key for ${data.aws_default_tags.default.tags.application} in ${data.aws_default_tags.default.tags.account}, for use with Make and Register, and Use a LPA"
-  policy      = data.aws_iam_policy_document.jwt_key_cross_account_access.json
-  kms_key_id  = module.jwt_kms.eu_west_1_target_key_id
+  # policy      = data.aws_iam_policy_document.jwt_key_cross_account_access.json
+  # kms_key_id  = module.jwt_kms.eu_west_1_target_key_id
   replica {
-    region     = data.aws_region.eu_west_2.name
-    kms_key_id = module.jwt_kms.eu_west_2_target_key_id
+    region = data.aws_region.eu_west_2.name
+    # kms_key_id = module.jwt_kms.eu_west_2_target_key_id
   }
   provider = aws.management_eu_west_1
 }
 
 data "aws_iam_policy_document" "jwt_key_cross_account_access" {
   statement {
+    effect = "Allow"
     actions = [
       "secretsmanager:GetSecretValue",
     ]
@@ -20,7 +21,7 @@ data "aws_iam_policy_document" "jwt_key_cross_account_access" {
     ]
     principals {
       type        = "AWS"
-      identifiers = local.account.jwt_key_cross_account_access_roles
+      identifiers = tolist(local.account.jwt_key_cross_account_access_roles)
     }
   }
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -5,7 +5,6 @@
       "account_name": "development",
       "is_production": false,
       "jwt_key_cross_account_access_roles": [
-          "arn:aws:iam::653761790766:root",
           "arn:aws:iam::653761790766:role/*-app-task-role",
           "arn:aws:iam::653761790766:role/event-received-*",
           "arn:aws:iam::288342028542:role/api-ecs-*"
@@ -17,7 +16,7 @@
       "is_production": false,
       "jwt_key_cross_account_access_roles": [
         "arn:aws:iam::792093328875:role/preproduction-app-task-role",
-        "arn:aws:iam::792093328875:role/event-received-*",
+        "arn:aws:iam::792093328875:role/event-received-preproduction",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction"
       ]
     },


### PR DESCRIPTION
# Purpose

Previous change resulted in an error for an invalid kms policy. Removing secret encryption and secret policy to unblock path to live while I resolve the issue

Fixes MLPAB-2237

## Approach

- Remove policy and kms id from secret
- fix reference to event-received preproduction
- remove reference to root access (though this with conditions may be the solution)

