### PR TITLE
MLPAB-2237 Allow KMS key and secret to be used across accouts

### DIFF
--- a/terraform/account/kms_key_jwt_secret.tf
+++ b/terraform/account/kms_key_jwt_secret.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "jwt_kms" {
     sid    = "Allow Key to be used for Encryption"
     effect = "Allow"
     resources = [
-      "arn:aws:kms:*:${data.aws_caller_identity.management.account_id}:key/*"
+      "*"
     ]
     actions = [
       "kms:Encrypt",
@@ -58,34 +58,39 @@ data "aws_iam_policy_document" "jwt_kms" {
     }
   }
 
-  # statement {
-  #   sid    = "Cross account access"
-  #   effect = "Allow"
-  #   resources = [
-  #     "arn:aws:kms:*:${data.aws_caller_identity.management.account_id}:key/*"
-  #   ]
-  #   actions = [
-  #     "kms:Decrypt",
-  #     "kms:GenerateDataKey*",
-  #     "kms:DescribeKey",
-  #   ]
+  statement {
+    sid    = "Cross account access"
+    effect = "Allow"
+    resources = [
+      "*"
+    ]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey",
+    ]
 
-  #   principals {
-  #     type = "AWS"
-  #     identifiers = concat(
-  #       local.account.jwt_key_cross_account_access_roles,
-  #       [
-  #         # allow all roles in the lpa-store-lambda path in the current account
-  #         "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/lpa-store-lambda/*",
-  #     ])
-  #   }
-  # }
+    principals {
+      type        = "AWS"
+      identifiers = local.account.jwt_key_cross_account_access
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values = concat(
+        local.account.jwt_key_cross_account_access_roles,
+        [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/lpa-store-lambda/*"
+      ])
+    }
+
+  }
 
   statement {
     sid    = "Key Administrator"
     effect = "Allow"
     resources = [
-      "arn:aws:kms:*:${data.aws_caller_identity.management.account_id}:key/*"
+      "*"
     ]
     actions = [
       "kms:Create*",
@@ -122,7 +127,7 @@ data "aws_iam_policy_document" "jwt_kms_development_account_operator_admin" {
     sid    = "Dev Account Key Administrator"
     effect = "Allow"
     resources = [
-      "arn:aws:kms:*:${data.aws_caller_identity.management.account_id}:key/*"
+      "*"
     ]
     actions = [
       "kms:Create*",
@@ -149,4 +154,3 @@ data "aws_iam_policy_document" "jwt_kms_development_account_operator_admin" {
     }
   }
 }
-

--- a/terraform/account/kms_key_jwt_secret.tf
+++ b/terraform/account/kms_key_jwt_secret.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "jwt_kms" {
 
     principals {
       type        = "AWS"
-      identifiers = local.account.jwt_key_cross_account_access
+      identifiers = concat(local.account.jwt_key_cross_account_access, ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"])
     }
     condition {
       test     = "ArnLike"

--- a/terraform/account/secrets.tf
+++ b/terraform/account/secrets.tf
@@ -1,11 +1,11 @@
 resource "aws_secretsmanager_secret" "jwt_key" {
   name        = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
   description = "JWT key for ${data.aws_default_tags.default.tags.application} in ${data.aws_default_tags.default.tags.account}, for use with Make and Register, and Use a LPA"
-  # policy      = data.aws_iam_policy_document.jwt_key_cross_account_access.json
-  # kms_key_id  = module.jwt_kms.eu_west_1_target_key_id
+  policy      = data.aws_iam_policy_document.jwt_key_cross_account_access.json
+  kms_key_id  = module.jwt_kms.eu_west_1_target_key_id
   replica {
-    region = data.aws_region.eu_west_2.name
-    # kms_key_id = module.jwt_kms.eu_west_2_target_key_id
+    region     = data.aws_region.eu_west_2.name
+    kms_key_id = module.jwt_kms.eu_west_2_target_key_id
   }
   provider = aws.management_eu_west_1
 }
@@ -13,15 +13,26 @@ resource "aws_secretsmanager_secret" "jwt_key" {
 data "aws_iam_policy_document" "jwt_key_cross_account_access" {
   statement {
     effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-    ]
     resources = [
       "*"
     ]
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
     principals {
       type        = "AWS"
-      identifiers = tolist(local.account.jwt_key_cross_account_access_roles)
+      identifiers = concat(local.account.jwt_key_cross_account_access, ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"])
     }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values = concat(
+        local.account.jwt_key_cross_account_access_roles,
+        [
+          "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/lpa-store-lambda/*"
+      ])
+    }
+
   }
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -4,6 +4,10 @@
       "account_id": "493907465011",
       "account_name": "development",
       "is_production": false,
+      "jwt_key_cross_account_access": [
+          "arn:aws:iam::653761790766:root",
+          "arn:aws:iam::288342028542:root"
+        ],
       "jwt_key_cross_account_access_roles": [
           "arn:aws:iam::653761790766:role/*-app-task-role",
           "arn:aws:iam::653761790766:role/event-received-*",
@@ -14,6 +18,10 @@
       "account_id": "936779158973",
       "account_name": "preproduction",
       "is_production": false,
+      "jwt_key_cross_account_access": [
+        "arn:aws:iam::792093328875:root",
+        "arn:aws:iam::492687888235:root"
+      ],
       "jwt_key_cross_account_access_roles": [
         "arn:aws:iam::792093328875:role/preproduction-app-task-role",
         "arn:aws:iam::792093328875:role/event-received-preproduction",
@@ -24,6 +32,10 @@
       "account_id": "764856231715",
       "account_name": "production",
       "is_production": true,
+      "jwt_key_cross_account_access": [
+        "arn:aws:iam::313879017102:root",
+        "arn:aws:iam::649098267436:root"
+      ],
       "jwt_key_cross_account_access_roles": [
         "arn:aws:iam::313879017102:role/production-app-task-role",
         "arn:aws:iam::313879017102:role/event-received-*",

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -4,6 +4,7 @@ variable "accounts" {
       account_id                         = string
       account_name                       = string
       is_production                      = bool
+      jwt_key_cross_account_access       = list(string)
       jwt_key_cross_account_access_roles = list(string)
     })
   )

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -51,3 +51,8 @@ data "aws_secretsmanager_secret" "jwt_secret_key" {
   name     = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
   provider = aws.management
 }
+
+data "aws_kms_alias" "jwt_key" {
+  name     = "alias/${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
+  provider = aws.management
+}

--- a/terraform/environment/region/data_sources.tf
+++ b/terraform/environment/region/data_sources.tf
@@ -6,7 +6,6 @@ data "aws_caller_identity" "current" {
   provider = aws.region
 }
 
-# we could use this data source instead of using an input variable for the account name
 data "aws_default_tags" "default" {
   provider = aws.region
 }
@@ -48,8 +47,7 @@ data "aws_subnets" "application" {
   provider = aws.region
 }
 
-# this can be updated in future to reference the shared secret in the management account
 data "aws_secretsmanager_secret" "jwt_secret_key" {
-  name     = "${data.aws_default_tags.default.tags.account}/jwt-key"
-  provider = aws.region
+  name     = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
+  provider = aws.management
 }

--- a/terraform/environment/region/iam.tf
+++ b/terraform/environment/region/iam.tf
@@ -107,5 +107,13 @@ data "aws_iam_policy_document" "lambda_secrets_policy" {
       "secretsmanager:GetSecretValue"
     ]
   }
+  statement {
+    sid       = "allowReadJwtSecretEncryption"
+    effect    = "Allow"
+    resources = [data.aws_kms_alias.jwt_key.target_key_arn]
+    actions = [
+      "secretsmanager:GetSecretValue"
+    ]
+  }
 }
 

--- a/terraform/environment/region/iam.tf
+++ b/terraform/environment/region/iam.tf
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "lambda_secrets_policy" {
     effect    = "Allow"
     resources = [data.aws_kms_alias.jwt_key.target_key_arn]
     actions = [
-      "secretsmanager:GetSecretValue"
+      "kms:Decrypt"
     ]
   }
 }

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "lambda" {
   name = "lambda-${var.lambda_name}-${var.environment_name}-${data.aws_region.current.name}"
   # this path will be used to grant permission to the lambda to access the KMS key
-  # path               = "/lpa-store-lambda/"
+  path               = "/lpa-store-lambda/"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
 
   lifecycle {


### PR DESCRIPTION
# Purpose

Make the JWT secret accessible by external account roles.

Fixes MLPAB-2237

## Approach

- Grant external account access to KMS key, and use conditions to restrict to specific roles
- Grant external account access to secret, using the same conditions
- Use CMK for secret encryption
- Move lambda IAM roles to path to make use in IAM policy documents easier
- Allow lambda to decrypt secret

## Learning

- https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying-external-accounts.html
- https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html
