### PR TITLE
apply plan output

### DIFF
--- a/.github/workflows/account-deploy.yml
+++ b/.github/workflows/account-deploy.yml
@@ -55,8 +55,7 @@ jobs:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
         run: |
           terraform workspace show
-          echo "plan_summary=$(terraform plan -no-color -lock-timeout=300s -input=false -parallelism=30 | grep -ioE 'Plan: [[:digit:]]+ to add, [[:digit:]]+ to change, [[:digit:]]+ to destroy|No changes. Your infrastructure matches the configuration.')" >> $GITHUB_OUTPUT
-          terraform plan -lock-timeout=300s -input=false -parallelism=30
+          terraform plan -lock-timeout=300s -input=false -parallelism=30 -out=terraform.plan
         working-directory: ./terraform/account
 
       - name: Terraform Apply
@@ -64,5 +63,5 @@ jobs:
         env:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
         run: |
-          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30
+          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 terraform.plan
         working-directory: ./terraform/account

--- a/.github/workflows/env-deploy.yml
+++ b/.github/workflows/env-deploy.yml
@@ -82,8 +82,7 @@ jobs:
           TF_VAR_app_version: ${{ inputs.version_tag }}
         run: |
           terraform workspace show
-          echo "plan_summary=$(terraform plan -no-color -lock-timeout=300s -input=false -parallelism=30 | grep -ioE 'Plan: [[:digit:]]+ to add, [[:digit:]]+ to change, [[:digit:]]+ to destroy|No changes. Your infrastructure matches the configuration.')" >> $GITHUB_OUTPUT
-          terraform plan -lock-timeout=300s -input=false -parallelism=30
+          terraform plan -lock-timeout=300s -input=false -parallelism=30 -out=terraform.plan
         working-directory: ./terraform/environment
 
       - name: Terraform Apply
@@ -92,7 +91,7 @@ jobs:
           TF_WORKSPACE: ${{ inputs.workspace_name }}
           TF_VAR_app_version: ${{ inputs.version_tag }}
         run: |
-          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30
+          terraform apply -lock-timeout=300s -input=false -auto-approve -parallelism=30 terraform.plan
         working-directory: ./terraform/environment
 
       - name: Terraform Outputs


### PR DESCRIPTION
# Purpose

output a plan and apply it, this will save on refreshing state a second time necessarily.

## Approach

- output a plan
- apply the outputted plan
- remove capturing plan output for PR comment summaries as they weren't being used and take up time

## Learning

- https://developer.hashicorp.com/terraform/cli/commands/plan
