### PR TITLE
MLPAB-2237 - remove old secret

### DIFF
--- a/terraform/account/region/secrets.tf
+++ b/terraform/account/region/secrets.tf
@@ -1,5 +1,0 @@
-resource "aws_secretsmanager_secret" "jwt_key" {
-  name = "${var.account_name}/jwt-key"
-
-  provider = aws.region
-}

--- a/terraform/account/region/variables.tf
+++ b/terraform/account/region/variables.tf
@@ -1,8 +1,3 @@
-variable "account_name" {
-  description = "Name of AWS account"
-  type        = string
-}
-
 variable "is_production" {
   description = "Whether this is a production environment"
   type        = bool

--- a/terraform/account/regions.tf
+++ b/terraform/account/regions.tf
@@ -1,7 +1,6 @@
 module "eu_west_1" {
   source = "./region"
 
-  account_name  = local.account.account_name
   is_production = local.account.is_production
   vpc_cidr      = "10.162.0.0/16"
 
@@ -14,7 +13,6 @@ module "eu_west_1" {
 module "eu_west_2" {
   source = "./region"
 
-  account_name  = local.account.account_name
   is_production = local.account.is_production
   vpc_cidr      = "10.163.0.0/16"
 


### PR DESCRIPTION
# Purpose

Now that lpa store and other services can use the shared key, we can remove the old one

Fixes MLPAB-2237

## Approach

- remove old secret (the one local to the service)
- remove unused variable

NOTE: Sirius and MLPAB needs to be using the shared secret before this is merged!
