### PR TITLE
MLPAB-2237 - use new secret in fixtures

### DIFF
--- a/terraform/environment/region/fixtures.tf
+++ b/terraform/environment/region/fixtures.tf
@@ -2,7 +2,6 @@ module "fixtures" {
   count  = var.has_fixtures ? 1 : 0
   source = "../../modules/fixtures_service"
 
-  account_name           = var.account_name
   application_subnet_ids = data.aws_subnets.application.ids
   cloudwatch_kms_key_id  = aws_kms_key.cloudwatch.arn
   ecr_image_uri          = "${data.aws_ecr_repository.fixtures[0].repository_url}:${var.app_version}"

--- a/terraform/modules/fixtures_service/data_sources.tf
+++ b/terraform/modules/fixtures_service/data_sources.tf
@@ -1,0 +1,9 @@
+data "aws_secretsmanager_secret" "jwt_secret_key" {
+  name     = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
+  provider = aws.management
+}
+
+data "aws_kms_alias" "jwt_key" {
+  name     = "alias/${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
+  provider = aws.management
+}

--- a/terraform/modules/fixtures_service/data_sources.tf
+++ b/terraform/modules/fixtures_service/data_sources.tf
@@ -7,3 +7,7 @@ data "aws_kms_alias" "jwt_key" {
   name     = "alias/${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
   provider = aws.management
 }
+
+data "aws_default_tags" "default" {
+  provider = aws.region
+}

--- a/terraform/modules/fixtures_service/iam.tf
+++ b/terraform/modules/fixtures_service/iam.tf
@@ -94,10 +94,19 @@ data "aws_iam_policy_document" "execution_role" {
   }
 
   statement {
+    sid       = "allowReadJwtSecret"
     effect    = "Allow"
     resources = [data.aws_secretsmanager_secret.jwt_secret_key.arn]
     actions = [
       "secretsmanager:GetSecretValue"
+    ]
+  }
+  statement {
+    sid       = "allowReadJwtSecretEncryption"
+    effect    = "Allow"
+    resources = [data.aws_kms_alias.jwt_key.target_key_arn]
+    actions = [
+      "kms:Decrypt"
     ]
   }
 

--- a/terraform/modules/fixtures_service/iam.tf
+++ b/terraform/modules/fixtures_service/iam.tf
@@ -45,6 +45,7 @@ data "aws_iam_policy_document" "task_role" {
 
 resource "aws_iam_role" "execution_role" {
   name_prefix        = "fixtures-execution-role-${var.environment_name}-"
+  path               = "/lpa-store-fixtures/"
   assume_role_policy = data.aws_iam_policy_document.execution_assume_role.json
 
   provider = aws.global

--- a/terraform/modules/fixtures_service/iam.tf
+++ b/terraform/modules/fixtures_service/iam.tf
@@ -1,5 +1,6 @@
 resource "aws_iam_role" "task_role" {
   name_prefix        = "fixtures-task-role-${var.environment_name}-"
+  path               = "/lpa-store-fixtures/"
   assume_role_policy = data.aws_iam_policy_document.ecs_task_role_assume_policy.json
 
   provider = aws.global

--- a/terraform/modules/fixtures_service/secrets.tf
+++ b/terraform/modules/fixtures_service/secrets.tf
@@ -1,5 +1,0 @@
-data "aws_secretsmanager_secret" "jwt_secret_key" {
-  name = "${var.account_name}/jwt-key"
-
-  provider = aws.region
-}

--- a/terraform/modules/fixtures_service/variables.tf
+++ b/terraform/modules/fixtures_service/variables.tf
@@ -1,8 +1,3 @@
-variable "account_name" {
-  description = "Name of AWS account"
-  type        = string
-}
-
 variable "application_subnet_ids" {
   description = "Application subnet IDs in VPC"
   type        = list(string)


### PR DESCRIPTION
# Purpose

Migrate to the new shared secret for jwt for fixtures app

Fixes MLPAB-2237

## Approach

- allow fixtures iam role to access secret and and kms key
- remove old secret