### PR TITLE
Force the initial value of selects to be "" #patch

### DIFF
--- a/fixtures/static/js/json-schema-editor.mjs
+++ b/fixtures/static/js/json-schema-editor.mjs
@@ -186,6 +186,10 @@ export class JsonSchemaEditor {
         $parent.appendChild(this.createGovukFormGroup(nub, $select));
 
         $select.dispatchEvent(new InputEvent("input"));
+
+        requestAnimationFrame(() => {
+          $select.value = "";
+        });
       } else if (schema.type === "string") {
         const $input = document.createElement("input");
         $input.id = `f-${pointer}`;


### PR DESCRIPTION
# Purpose

Due to a some browser/rendering weirdness, when <select>s are added to the page their initial value is `""` but they're shown as having the first non-empty value selected.

## Approach

Use `requestAnimationFrame` to force the value to be `""` immediately. rAF is necessary to let the browser's initial state settle first.

