### PR TITLE
Fix default values in fixtures app

### DIFF
--- a/fixtures/static/js/json-schema-editor.mjs
+++ b/fixtures/static/js/json-schema-editor.mjs
@@ -95,6 +95,7 @@ export class JsonSchemaEditor {
     const value = JSON.parse(this.$module.value);
 
     const data = jsonSchema.getTemplate(value);
+    this.$module.value = JSON.stringify(data);
 
     this.$formContainer.innerHTML = "";
     this.constructElements(this.$formContainer, data, jsonSchema);
@@ -186,10 +187,6 @@ export class JsonSchemaEditor {
         $parent.appendChild(this.createGovukFormGroup(nub, $select));
 
         $select.dispatchEvent(new InputEvent("input"));
-
-        requestAnimationFrame(() => {
-          $select.value = "";
-        });
       } else if (schema.type === "string") {
         const $input = document.createElement("input");
         $input.id = `f-${pointer}`;


### PR DESCRIPTION
# Purpose

Currently the values shown on screen are auto-filled based on the schema. This includes selecting the first value of enum dropdowns. But the data saved in the textarea (which is ultimately sent to the API) doesn't have these which can cause confusion.

#patch 

## Approach

To ensure alignment, after filling in default values save the new data back to the textarea so that it represents what's actually being displayed.

This makes the textarea slightly harder to edit manually, but no-one's doing that anyway.

This replaces the `requestAnimationFrame` fix which just caused different issues.