### PR TITLE
Remove identityCheck from the fixture form #patch

### DIFF
--- a/fixtures/static/js/json-schema-editor.mjs
+++ b/fixtures/static/js/json-schema-editor.mjs
@@ -51,6 +51,11 @@ export class JsonSchemaEditor {
     const response = await fetch(url);
     this.schema = await response.json();
 
+    // TODO - Find a better solution
+    // HACK - Remove these from the schema so that blank values are not sent to the API
+    delete this.schema.properties.donor.properties.identityCheck;
+    delete this.schema.properties.certificateProvider.properties.identityCheck;
+
     const $container = document.createElement("div");
     this.$formContainer = $container;
 


### PR DESCRIPTION
When unpopulated donor.identityCheck and certificateProvider.identityCheck are being sent with blank values. This causes an Unmarshalling error in the API. To allow creation of test data for a demo of paper ID these are temporarily being removed from the fixture form.