### PR TITLE
Use ECR-hosted Trivy DB rather than public image

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -55,21 +55,7 @@ jobs:
         id: build_image
         run: |
           docker compose build ${{ matrix.container }}
-      - name: Trivy Image Vulnerability Scanner for ${{ matrix.ecr_repository }}
-        id: trivy_scan
-        uses: aquasecurity/trivy-action@0.24.0
-        with:
-          image-ref: ${{ matrix.ecr_repository }}:latest
-          severity: "HIGH,CRITICAL"
-          format: "sarif"
-          output: "trivy-results.sarif"
-      - name: Upload Trivy scan results to GitHub Security tab for ${{ matrix.ecr_repository }}
-        id: trivy_upload_sarif
-        uses: github/codeql-action/upload-sarif@v3
-        if: always()
-        with:
-          sarif_file: "trivy-results.sarif"
-      - uses: unfor19/install-aws-cli-action@v1
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -85,6 +71,26 @@ jobs:
         with:
           mask-password: true
           registries: 311462405659
+
+      - name: Trivy Image Vulnerability Scanner for ${{ matrix.ecr_repository }}
+        id: trivy_scan
+        uses: aquasecurity/trivy-action@0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-java-db:1
+        with:
+          image-ref: ${{ matrix.ecr_repository }}:latest
+          severity: "HIGH,CRITICAL"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          vuln-type: 'os,library'
+      - name: Upload Trivy scan results to GitHub Security tab for ${{ matrix.ecr_repository }}
+        id: trivy_upload_sarif
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"
+
       - name: Push ${{ matrix.ecr_repository }} Image to ECR
         env:
           ECR_REGISTRY: ${{ steps.login_ecr.outputs.registry }}


### PR DESCRIPTION
# Purpose

To avoid getting caught by rate limiting on the public resource.

#patch

## Approach

Copied from [Paper ID](https://github.com/ministryofjustice/opg-paper-identity/pull/258)
