### PR TITLE
VEGA-2501 : Manual Status Change #minor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       context: .
       dockerfile: ./mock-apigw/Dockerfile
     ports:
-      - 9010:9001
+      - 9000:8080
 
   localstack:
     image: localstack/localstack:3.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       context: .
       dockerfile: ./mock-apigw/Dockerfile
     ports:
-      - 9000:8080
+      - 9010:9001
 
   localstack:
     image: localstack/localstack:3.7

--- a/docs/opg-status-change.json
+++ b/docs/opg-status-change.json
@@ -1,0 +1,10 @@
+{
+    "type": "OPG_STATUS_CHANGE",
+    "changes": [
+        {
+            "key": "/status",
+            "new": "cannot-register",
+            "old": "in-progress"
+        }
+    ]
+}

--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -54,4 +54,9 @@ const (
 	LpaStatusRegistered             = LpaStatus("registered")
 	LpaStatusCannotRegister         = LpaStatus("cannot-register")
 	LpaStatusWithdrawn              = LpaStatus("withdrawn")
+	LpaStatusCancelled              = LpaStatus("cancelled")
 )
+
+func (l LpaStatus) IsValid() bool {
+	return l == LpaStatusInProgress || l == LpaStatusStatutoryWaitingPeriod || l == LpaStatusRegistered || l == LpaStatusCannotRegister || l == LpaStatusWithdrawn || l == LpaStatusCancelled
+}

--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -13,15 +13,15 @@ type OpgChangeStatus struct {
 func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 	if r.Status != shared.LpaStatusCannotRegister {
-		return []shared.FieldError{{Source: "/type", Detail: "Status to be updated should be cannot register"}}
+		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register"}}
 	}
 
 	if lpa.Status == shared.LpaStatusRegistered {
-		return []shared.FieldError{{Source: "/type", Detail: "Lpa status cannot be registered"}}
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be registered"}}
 	}
 
 	if lpa.Status == shared.LpaStatusCancelled {
-		return []shared.FieldError{{Source: "/type", Detail: "Lpa status cannot be cancelled"}}
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be cancelled"}}
 	}
 
 	lpa.Status = r.Status

--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+)
+
+type OpgChangeStatus struct{}
+
+func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
+	if lpa.Status == shared.LpaStatusRegistered {
+		return []shared.FieldError{{Source: "/type", Detail: "status must not be registered"}}
+	}
+
+	lpa.Status = shared.LpaStatusCannotRegister
+
+	return nil
+}
+
+func validateOpgChangeStatus(changes []shared.Change) (OpgChangeStatus, []shared.FieldError) {
+
+	return OpgChangeStatus{}, nil
+}

--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -2,21 +2,44 @@ package main
 
 import (
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
+	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
 )
 
-type OpgChangeStatus struct{}
+type OpgChangeStatus struct {
+	Status shared.LpaStatus
+}
 
 func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
-	if lpa.Status == shared.LpaStatusRegistered {
-		return []shared.FieldError{{Source: "/type", Detail: "status must not be registered"}}
+
+	if r.Status != shared.LpaStatusCannotRegister {
+		return []shared.FieldError{{Source: "/type", Detail: "Status to be updated should be cannot register"}}
 	}
 
-	lpa.Status = shared.LpaStatusCannotRegister
+	if lpa.Status == shared.LpaStatusRegistered {
+		return []shared.FieldError{{Source: "/type", Detail: "Lpa status cannot be registered"}}
+	}
+
+	if lpa.Status == shared.LpaStatusCancelled {
+		return []shared.FieldError{{Source: "/type", Detail: "Lpa status cannot be cancelled"}}
+	}
+
+	lpa.Status = r.Status
 
 	return nil
 }
 
-func validateOpgChangeStatus(changes []shared.Change) (OpgChangeStatus, []shared.FieldError) {
+func validateOpgChangeStatus(changes []shared.Change, lpa *shared.Lpa) (OpgChangeStatus, []shared.FieldError) {
 
-	return OpgChangeStatus{}, nil
+	var data OpgChangeStatus
+
+	data.Status = lpa.Status
+
+	errors := parse.Changes(changes).
+		Field("/status", &data.Status, parse.Validate(func() []shared.FieldError {
+			return validate.IsValid("", data.Status)
+		})).
+		Consumed()
+
+	return data, errors
 }

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOpgChangeStatusApply(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusInProgress,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusCannotRegister,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, c.Status, lpa.Status)
+}
+
+func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusInProgress,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusWithdrawn,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "Status to be updated should be cannot register"}})
+}
+
+func TestOpgChangeStatusIncorrectExistingStatus(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusRegistered,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusCannotRegister,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "Lpa status cannot be registered"}})
+}
+
+func TestValidateUpdateOPGChangeStatus(t *testing.T) {
+	testcases := map[string]struct {
+		update shared.Update
+		lpa    *shared.Lpa
+		errors []shared.FieldError
+	}{
+		"valid - with previous values": {
+			update: shared.Update{
+				Type: "OPG_CHANGE_STATUS",
+				Changes: []shared.Change{
+					{
+						Key: "/status",
+						New: json.RawMessage(`"cannot-register"`),
+						Old: json.RawMessage(`"in-progress"`),
+					},
+				},
+			},
+			lpa: &shared.Lpa{
+				Status: shared.LpaStatusInProgress,
+			},
+		},
+		"invalid status": {
+			update: shared.Update{
+				Type: "OPG_CHANGE_STATUS",
+				Changes: []shared.Change{
+					{
+						Key: "/status",
+						New: json.RawMessage(`"never-register"`),
+						Old: json.RawMessage(`"in-progress"`),
+					},
+				},
+			},
+			lpa: &shared.Lpa{
+				Status: shared.LpaStatusInProgress,
+			},
+			errors: []shared.FieldError{
+				{Source: "/changes/0/new", Detail: "invalid value"},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			_, errors := validateUpdate(tc.update, tc.lpa)
+			assert.ElementsMatch(t, tc.errors, errors)
+		})
+	}
+}

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -52,7 +52,7 @@ func TestValidateUpdateOPGChangeStatus(t *testing.T) {
 	}{
 		"valid - with previous values": {
 			update: shared.Update{
-				Type: "OPG_CHANGE_STATUS",
+				Type: "OPG_STATUS_CHANGE",
 				Changes: []shared.Change{
 					{
 						Key: "/status",
@@ -67,7 +67,7 @@ func TestValidateUpdateOPGChangeStatus(t *testing.T) {
 		},
 		"invalid status": {
 			update: shared.Update{
-				Type: "OPG_CHANGE_STATUS",
+				Type: "OPG_STATUS_CHANGE",
 				Changes: []shared.Change{
 					{
 						Key: "/status",

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -29,7 +29,7 @@ func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "Status to be updated should be cannot register"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register"}})
 }
 
 func TestOpgChangeStatusIncorrectExistingStatus(t *testing.T) {
@@ -41,7 +41,7 @@ func TestOpgChangeStatusIncorrectExistingStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/type", Detail: "Lpa status cannot be registered"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be registered"}})
 }
 
 func TestValidateUpdateOPGChangeStatus(t *testing.T) {

--- a/lambda/update/parse/changes.go
+++ b/lambda/update/parse/changes.go
@@ -163,6 +163,13 @@ func oldEqualsExisting(old any, existing any) bool {
 
 		return shared.IdentityCheckType(old.(string)) == *v
 
+	case *shared.LpaStatus:
+		if old == nil {
+			return *v == ""
+		}
+
+		return shared.LpaStatus(old.(string)) == *v
+
 	case *string:
 		if old == nil {
 			return *v == ""

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -21,7 +21,7 @@ func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.
 	case "REGISTER":
 		return validateRegister(update.Changes)
 	case "OPG_CHANGE_STATUS":
-		return validateOpgChangeStatus(update.Changes)
+		return validateOpgChangeStatus(update.Changes, lpa)
 	case "TRUST_CORPORATION_SIGN":
 		return validateTrustCorporationSign(update.Changes, lpa)
 	case "DONOR_CONFIRM_IDENTITY":

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -20,6 +20,8 @@ func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.
 		return validateStatutoryWaitingPeriod(update.Changes)
 	case "REGISTER":
 		return validateRegister(update.Changes)
+	case "OPG_CHANGE_STATUS":
+		return validateOpgChangeStatus(update.Changes)
 	case "TRUST_CORPORATION_SIGN":
 		return validateTrustCorporationSign(update.Changes, lpa)
 	case "DONOR_CONFIRM_IDENTITY":

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -20,7 +20,7 @@ func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.
 		return validateStatutoryWaitingPeriod(update.Changes)
 	case "REGISTER":
 		return validateRegister(update.Changes)
-	case "OPG_CHANGE_STATUS":
+	case "OPG_STATUS_CHANGE":
 		return validateOpgChangeStatus(update.Changes, lpa)
 	case "TRUST_CORPORATION_SIGN":
 		return validateTrustCorporationSign(update.Changes, lpa)


### PR DESCRIPTION
# Purpose

This covers [VEGA-2501](https://opgtransform.atlassian.net/browse/VEGA-2501)

## Approach

The changes add a new validation / application file for changing the status manually. Currently, the implementation only allows the status change to 'Cannot register'. This can / will be extended / modified to include other statuses as new requirements come along. It will just need additions / amendments to the logic inside **opg_status_change.go**



[VEGA-2501]: https://opgtransform.atlassian.net/browse/VEGA-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ