### PR TITLE
Default date fields to null

### DIFF
--- a/fixtures/static/js/json-schema-editor.mjs
+++ b/fixtures/static/js/json-schema-editor.mjs
@@ -100,6 +100,7 @@ export class JsonSchemaEditor {
     const value = JSON.parse(this.$module.value);
 
     const data = jsonSchema.getTemplate(value);
+    this.nullEmptyDates(data);
     this.$module.value = JSON.stringify(data);
 
     this.$formContainer.innerHTML = "";
@@ -109,6 +110,19 @@ export class JsonSchemaEditor {
     const $inputs = this.$formContainer.querySelectorAll("input,select");
     $inputs.forEach(($input) => {
       $input.value = jsonGet(value, $input.getAttribute("name")) ?? "";
+    });
+  }
+
+  nullEmptyDates(data) {
+    [
+      "/signedAt",
+      "/witnessedByCertificateProviderAt",
+      "/witnessedByIndependentWitnessAt",
+      "/certificateProviderNotRelatedConfirmedAt",
+    ].forEach((datePointer) => {
+      if (jsonGet(data, datePointer) === "") {
+        jsonSet(data, datePointer, null);
+      }
     });
   }
 


### PR DESCRIPTION
# Purpose

json-schema-library is defaulting al text fields to empty strings. This is fine for general text fields, but causes problems for dates as the the API then tries to unmarshal the string and finds it isn't a valid ISO-8601 date.

Empty date strings should instead be treated as `null` so that unmarshaling is skipped.

Fixes VEGA-2708 #patch

## Approach

When writing default values into the JSON object, specifically convert empty-string date fields to null.

## Learning

This awkwardness was caused because other fields need to be defaulted to a valid value in order to show in the UI properly. In the future, replacing this with a properly designed form and/or scanning will give us much better control over default values.
