### PR TITLE
Update the JWT secret and change the port on fixtures service #patch

### DIFF
--- a/.github/workflows/pact-provider-verification.yml
+++ b/.github/workflows/pact-provider-verification.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: 'stable'
       - run: go build -o ./api-test/tester ./api-test && chmod +x ./api-test/tester
-      - run: echo "JWT=$(JWT_SECRET_KEY=secret ./api-test/tester JWT)" >> "$GITHUB_ENV"
+      - run: echo "JWT=$(JWT_SECRET_KEY=mysupersecrettestkeythatis128bits ./api-test/tester JWT)" >> "$GITHUB_ENV"
       - name: Verify specified Pact
         if: ${{ github.event_name == 'repository_dispatch' }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = '/bin/bash'
-export JWT_SECRET_KEY ?= secret
+export JWT_SECRET_KEY ?= mysupersecrettestkeythatis128bits
 
 help:
 	@grep --no-filename -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -17,7 +17,7 @@ test: ## Unit tests
 	go test ./... -race -covermode=atomic -coverprofile=coverage.out
 
 test-api: URL ?= http://localhost:9000
-# test-api: export JWT_SECRET_KEY ?= secret
+# test-api: export JWT_SECRET_KEY ?= mysupersecrettestkeythatis128bits
 test-api:
 	$(shell go build -o ./api-test/tester ./api-test && chmod +x ./api-test/tester)
 	$(eval LPA_UID := "$(shell ./api-test/tester UID)")
@@ -77,7 +77,7 @@ test-api:
 .PHONY: test-api
 
 test-pact:
-	$(eval JWT := "$(shell JWT_SECRET_KEY=secret ./api-test/tester JWT)")
+	$(eval JWT := "$(shell JWT_SECRET_KEY=mysupersecrettestkeythatis128bits ./api-test/tester JWT)")
 
 	docker compose run --rm pact-verifier \
       --header="X-Jwt-Authorization=Bearer $(JWT)" \

--- a/api-test/main.go
+++ b/api-test/main.go
@@ -22,9 +22,9 @@ import (
 
 // ./api-test/tester UID -> generate a UID
 // ./api-test/tester JWT -> generate a JWT
-// JWT_SECRET_KEY=secret ./api-test/tester -expectedStatus=200 REQUEST <METHOD> <URL> <REQUEST BODY>
+// JWT_SECRET_KEY=mysupersecrettestkeythatis128bits ./api-test/tester -expectedStatus=200 REQUEST <METHOD> <URL> <REQUEST BODY>
 //
-//	-> make a test request with a JWT generated using secret "secret" and expected status 200
+//	-> make a test request with a JWT generated using secret "mysupersecrettestkeythatis128bits" and expected status 200
 //
 // note that the jwtSecret sends a boilerplate JWT for now with valid iat, exp, iss and sub fields
 func main() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,11 +146,11 @@ services:
       context: .
       dockerfile: ./fixtures/Dockerfile
     ports:
-      - "5000:80"
+      - "5000:8080"
     environment:
       - SKIP_AUTH=1
       - BASE_URL=http://apigw:8080
-      - JWT_SECRET_KEY=secret
+      - JWT_SECRET_KEY=mysupersecrettestkeythatis128bits
     volumes:
       - ./fixtures/static/js:/app/static/js
       - ./docs/schemas:/app/static/schemas

--- a/internal/shared/jwt_test.go
+++ b/internal/shared/jwt_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var secretKey = []byte("secret")
+var secretKey = []byte("mysupersecrettestkeythatis128bits")
 
 var verifier = JWTVerifier{
 	secretKey: secretKey,

--- a/localstack/init/localstack_init.sh
+++ b/localstack/init/localstack_init.sh
@@ -48,4 +48,4 @@ awslocal dynamodb create-table \
 # Secrets Manager
 awslocal secretsmanager create-secret --name local/jwt-key \
     --description "JWT secret for service authentication" \
-    --secret-string "secret"
+    --secret-string "mysupersecrettestkeythatis128bits"


### PR DESCRIPTION
# Purpose

This PR updates the JWT secret across the LPA Store so that it matches the JWT secret being sent from Sirius thereby allowing a local setup between both without any manual updates to the JWT secret key.

## Approach

Everywhere where the old JWT secret is being used has been replaced with the new one.

## Learning

There is a file - opg-data-lpa-store/terraform/account/kms_key_jwt_secret.tf. I am unsure about whether a change is needed in the section below in BOLD or whether its just a description text -
```

module "jwt_kms" {
  source                  = "../modules/kms_key"
  **encrypted_resource      = "jwt key secret"**
  kms_key_alias_name      = "${data.aws_default_tags.default.tags.application}/${data.aws_default_tags.default.tags.account}/jwt-key"
  enable_key_rotation     = true
  enable_multi_region     = true
  deletion_window_in_days = 10
  kms_key_policy          = data.aws_default_tags.default.tags.account == "development" ? data.aws_iam_policy_document.jwt_kms_merged.json : data.aws_iam_policy_document.jwt_kms.json
  providers = {
    aws.eu_west_1 = aws.management_eu_west_1
    aws.eu_west_2 = aws.management_eu_west_2
  }
}
```
