### PR TITLE
VEGA-2500 : Handle manual change to cancelled status #minor

### DIFF
--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -12,16 +12,20 @@ type OpgChangeStatus struct {
 
 func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
-	if r.Status != shared.LpaStatusCannotRegister {
-		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register"}}
+	if r.Status != shared.LpaStatusCannotRegister && r.Status != shared.LpaStatusCancelled {
+		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register or cancelled"}}
 	}
 
-	if lpa.Status == shared.LpaStatusRegistered {
-		return []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be registered"}}
+	if r.Status == shared.LpaStatusCannotRegister && lpa.Status == shared.LpaStatusRegistered {
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be registered while changing to cannot register"}}
 	}
 
-	if lpa.Status == shared.LpaStatusCancelled {
-		return []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be cancelled"}}
+	if r.Status == shared.LpaStatusCannotRegister && lpa.Status == shared.LpaStatusCancelled {
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be cancelled while changing to cannot register"}}
+	}
+
+	if r.Status == shared.LpaStatusCancelled && lpa.Status != shared.LpaStatusRegistered {
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be registered while changing to cancelled"}}
 	}
 
 	lpa.Status = r.Status

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -7,12 +7,25 @@ import (
 	"testing"
 )
 
-func TestOpgChangeStatusApply(t *testing.T) {
+func TestOpgChangeStatusToCannotRegisterApply(t *testing.T) {
 	lpa := &shared.Lpa{
 		Status: shared.LpaStatusInProgress,
 	}
 	c := OpgChangeStatus{
 		Status: shared.LpaStatusCannotRegister,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, c.Status, lpa.Status)
+}
+
+func TestOpgChangeStatusToCancelledApply(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusRegistered,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusCancelled,
 	}
 
 	errors := c.Apply(lpa)
@@ -29,10 +42,10 @@ func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register or cancelled"}})
 }
 
-func TestOpgChangeStatusIncorrectExistingStatus(t *testing.T) {
+func TestOpgChangeStatusToCannotRegisterIncorrectExistingStatus(t *testing.T) {
 	lpa := &shared.Lpa{
 		Status: shared.LpaStatusRegistered,
 	}
@@ -41,7 +54,19 @@ func TestOpgChangeStatusIncorrectExistingStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be registered"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status cannot be registered while changing to cannot register"}})
+}
+
+func TestOpgChangeStatusToCancelledIncorrectExistingStatus(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusInProgress,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusCancelled,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be registered while changing to cancelled"}})
 }
 
 func TestValidateUpdateOPGChangeStatus(t *testing.T) {


### PR DESCRIPTION
# Purpose

This PR covers [VEGA-2500](https://opgtransform.atlassian.net/browse/VEGA-2500)

The PR change adds new rules to the OPG_STATUS_CHANGE change type to include the manual case status update to the 'Cancelled' status. The tests have been updated.

## Approach

The logic checks the old values and new values to ensure that they conform to the business rules for changing the status manually to 'Cancelled' and also ensures that the existing logic around the manual case status update to 'Cannot Register' still continues to work.

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service


[VEGA-2500]: https://opgtransform.atlassian.net/browse/VEGA-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ