### PR TITLE
VEGA-2638 : Handle Do Not Register status update  #minor

### DIFF
--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -59,8 +59,9 @@ const (
 	LpaStatusCannotRegister         = LpaStatus("cannot-register")
 	LpaStatusWithdrawn              = LpaStatus("withdrawn")
 	LpaStatusCancelled              = LpaStatus("cancelled")
+	LpaStatusDoNotRegister          = LpaStatus("do-not-register")
 )
 
 func (l LpaStatus) IsValid() bool {
-	return l == LpaStatusInProgress || l == LpaStatusStatutoryWaitingPeriod || l == LpaStatusRegistered || l == LpaStatusCannotRegister || l == LpaStatusWithdrawn || l == LpaStatusCancelled
+	return l == LpaStatusInProgress || l == LpaStatusStatutoryWaitingPeriod || l == LpaStatusRegistered || l == LpaStatusCannotRegister || l == LpaStatusWithdrawn || l == LpaStatusCancelled || l == LpaStatusDoNotRegister
 }

--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -12,8 +12,8 @@ type OpgChangeStatus struct {
 
 func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
-	if r.Status != shared.LpaStatusCannotRegister && r.Status != shared.LpaStatusCancelled {
-		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register or cancelled"}}
+	if r.Status != shared.LpaStatusCannotRegister && r.Status != shared.LpaStatusCancelled && r.Status != shared.LpaStatusDoNotRegister {
+		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled or do not register"}}
 	}
 
 	if r.Status == shared.LpaStatusCannotRegister && lpa.Status == shared.LpaStatusRegistered {
@@ -26,6 +26,10 @@ func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 	if r.Status == shared.LpaStatusCancelled && lpa.Status != shared.LpaStatusRegistered {
 		return []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be registered while changing to cancelled"}}
+	}
+
+	if r.Status == shared.LpaStatusDoNotRegister && lpa.Status != shared.LpaStatusStatutoryWaitingPeriod {
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be statutory waiting period while changing to do not register"}}
 	}
 
 	lpa.Status = r.Status

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -87,11 +87,11 @@ func TestOpgChangeStatusToDoNotRegisterIncorrectExistingStatus(t *testing.T) {
 		Status: shared.LpaStatusInProgress,
 	}
 	c := OpgChangeStatus{
-		Status: shared.LpaStatusCancelled,
+		Status: shared.LpaStatusDoNotRegister,
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be registered while changing to cancelled"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be statutory waiting period while changing to do not register"}})
 }
 
 func TestValidateUpdateOPGChangeStatus(t *testing.T) {

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -33,6 +33,19 @@ func TestOpgChangeStatusToCancelledApply(t *testing.T) {
 	assert.Equal(t, c.Status, lpa.Status)
 }
 
+func TestOpgChangeStatusToDoNotRegisterApply(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusStatutoryWaitingPeriod,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusDoNotRegister,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, c.Status, lpa.Status)
+}
+
 func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	lpa := &shared.Lpa{
 		Status: shared.LpaStatusInProgress,
@@ -42,7 +55,7 @@ func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register or cancelled"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled or do not register"}})
 }
 
 func TestOpgChangeStatusToCannotRegisterIncorrectExistingStatus(t *testing.T) {
@@ -58,6 +71,18 @@ func TestOpgChangeStatusToCannotRegisterIncorrectExistingStatus(t *testing.T) {
 }
 
 func TestOpgChangeStatusToCancelledIncorrectExistingStatus(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusInProgress,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusCancelled,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be registered while changing to cancelled"}})
+}
+
+func TestOpgChangeStatusToDoNotRegisterIncorrectExistingStatus(t *testing.T) {
 	lpa := &shared.Lpa{
 		Status: shared.LpaStatusInProgress,
 	}


### PR DESCRIPTION
# Purpose

This PR covers [VEGA-2638](https://opgtransform.atlassian.net/browse/VEGA-2638)

## Approach

The existing validations have been updated and new one added to implement the status change for 'Do Not Register'. The tests have been updated.

## Learning



[VEGA-2638]: https://opgtransform.atlassian.net/browse/VEGA-2638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ