### PR TITLE
VEGA-2661 : Handle manual update of Expired status #minor

### DIFF
--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -60,8 +60,9 @@ const (
 	LpaStatusWithdrawn              = LpaStatus("withdrawn")
 	LpaStatusCancelled              = LpaStatus("cancelled")
 	LpaStatusDoNotRegister          = LpaStatus("do-not-register")
+	LpaStatusExpired                = LpaStatus("expired")
 )
 
 func (l LpaStatus) IsValid() bool {
-	return l == LpaStatusInProgress || l == LpaStatusStatutoryWaitingPeriod || l == LpaStatusRegistered || l == LpaStatusCannotRegister || l == LpaStatusWithdrawn || l == LpaStatusCancelled || l == LpaStatusDoNotRegister
+	return l == LpaStatusInProgress || l == LpaStatusStatutoryWaitingPeriod || l == LpaStatusRegistered || l == LpaStatusCannotRegister || l == LpaStatusWithdrawn || l == LpaStatusCancelled || l == LpaStatusDoNotRegister || l == LpaStatusExpired
 }

--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -12,8 +12,8 @@ type OpgChangeStatus struct {
 
 func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
-	if r.Status != shared.LpaStatusCannotRegister && r.Status != shared.LpaStatusCancelled && r.Status != shared.LpaStatusDoNotRegister {
-		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled or do not register"}}
+	if r.Status != shared.LpaStatusCannotRegister && r.Status != shared.LpaStatusCancelled && r.Status != shared.LpaStatusDoNotRegister && r.Status != shared.LpaStatusExpired {
+		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled, do not register or expired"}}
 	}
 
 	if r.Status == shared.LpaStatusCannotRegister && lpa.Status == shared.LpaStatusRegistered {
@@ -30,6 +30,10 @@ func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 	if r.Status == shared.LpaStatusDoNotRegister && lpa.Status != shared.LpaStatusStatutoryWaitingPeriod {
 		return []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be statutory waiting period while changing to do not register"}}
+	}
+
+	if r.Status == shared.LpaStatusExpired && lpa.Status != shared.LpaStatusInProgress && lpa.Status != shared.LpaStatusStatutoryWaitingPeriod && lpa.Status != shared.LpaStatusDoNotRegister {
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be in progress, statutory waiting period or do not register while changing to expired"}}
 	}
 
 	lpa.Status = r.Status

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -46,6 +46,19 @@ func TestOpgChangeStatusToDoNotRegisterApply(t *testing.T) {
 	assert.Equal(t, c.Status, lpa.Status)
 }
 
+func TestOpgChangeStatusToExpiredApply(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusStatutoryWaitingPeriod,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusExpired,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, c.Status, lpa.Status)
+}
+
 func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	lpa := &shared.Lpa{
 		Status: shared.LpaStatusInProgress,
@@ -55,7 +68,7 @@ func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled or do not register"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled, do not register or expired"}})
 }
 
 func TestOpgChangeStatusToCannotRegisterIncorrectExistingStatus(t *testing.T) {
@@ -92,6 +105,18 @@ func TestOpgChangeStatusToDoNotRegisterIncorrectExistingStatus(t *testing.T) {
 
 	errors := c.Apply(lpa)
 	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be statutory waiting period while changing to do not register"}})
+}
+
+func TestOpgChangeStatusToExpiredIncorrectExistingStatus(t *testing.T) {
+	lpa := &shared.Lpa{
+		Status: shared.LpaStatusRegistered,
+	}
+	c := OpgChangeStatus{
+		Status: shared.LpaStatusExpired,
+	}
+
+	errors := c.Apply(lpa)
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa status has to be in progress, statutory waiting period or do not register while changing to expired"}})
 }
 
 func TestValidateUpdateOPGChangeStatus(t *testing.T) {


### PR DESCRIPTION
# Purpose

This PR covers [VEGA-2661](https://opgtransform.atlassian.net/browse/VEGA-2661) allowing the change of Lpa status to Expired while the status is In Progress, Statutory Waiting Period or Do not register.

[VEGA-2661]: https://opgtransform.atlassian.net/browse/VEGA-2661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ