### PR TITLE
Vega 2656 add appointment type and new status

### DIFF
--- a/docs/example-lpa.json
+++ b/docs/example-lpa.json
@@ -26,6 +26,7 @@
       },
       "dateOfBirth": "1982-07-24",
       "status": "active",
+      "appointmentType": "original",
       "channel": "paper"
     }
   ],

--- a/docs/schemas/2024-10/lpa.json
+++ b/docs/schemas/2024-10/lpa.json
@@ -43,6 +43,14 @@
           "signedAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive", "replacement", "removed"]
+          },
+          "appointmentType": {
+            "type": "string",
+            "enum": ["original", "replacement"]
           }
         }
       }

--- a/internal/shared/person.go
+++ b/internal/shared/person.go
@@ -57,24 +57,37 @@ type AttorneyStatus string
 
 const (
 	AttorneyStatusActive      = AttorneyStatus("active")
+	AttorneyStatusInactive    = AttorneyStatus("inactive")
 	AttorneyStatusReplacement = AttorneyStatus("replacement")
 	AttorneyStatusRemoved     = AttorneyStatus("removed")
 )
 
 func (a AttorneyStatus) IsValid() bool {
-	return a == AttorneyStatusActive || a == AttorneyStatusReplacement || a == AttorneyStatusRemoved
+	return a == AttorneyStatusActive || a == AttorneyStatusReplacement || a == AttorneyStatusRemoved || a == AttorneyStatusInactive
+}
+
+type AppointmentType string
+
+const (
+	AppointmentTypeOriginal    = AppointmentType("original")
+	AppointmentTypeReplacement = AppointmentType("replacement")
+)
+
+func (a AppointmentType) IsValid() bool {
+	return a == AppointmentTypeOriginal || a == AppointmentTypeReplacement
 }
 
 type Attorney struct {
 	Person
-	Address                   Address        `json:"address"`
-	DateOfBirth               Date           `json:"dateOfBirth"`
-	Email                     string         `json:"email,omitempty"`
-	Status                    AttorneyStatus `json:"status"`
-	Mobile                    string         `json:"mobile,omitempty"`
-	SignedAt                  *time.Time     `json:"signedAt,omitempty"`
-	ContactLanguagePreference Lang           `json:"contactLanguagePreference,omitempty"`
-	Channel                   Channel        `json:"channel"`
+	Address                   Address         `json:"address"`
+	DateOfBirth               Date            `json:"dateOfBirth"`
+	Email                     string          `json:"email,omitempty"`
+	Status                    AttorneyStatus  `json:"status"`
+	AppointmentType           AppointmentType `json:"appointmentType"`
+	Mobile                    string          `json:"mobile,omitempty"`
+	SignedAt                  *time.Time      `json:"signedAt,omitempty"`
+	ContactLanguagePreference Lang            `json:"contactLanguagePreference,omitempty"`
+	Channel                   Channel         `json:"channel"`
 }
 
 type TrustCorporation struct {

--- a/internal/shared/person.go
+++ b/internal/shared/person.go
@@ -74,7 +74,7 @@ const (
 )
 
 func (a AppointmentType) IsValid() bool {
-	return a == AppointmentTypeOriginal || a == AppointmentTypeReplacement
+	return true
 }
 
 type Attorney struct {

--- a/lambda/create/main_test.go
+++ b/lambda/create/main_test.go
@@ -47,6 +47,7 @@ var (
 				Line1:   "attorney-line1",
 				Country: "GB",
 			},
+			AppointmentType:           shared.AppointmentTypeOriginal,
 			DateOfBirth:               makeDate("2020-02-03"),
 			ContactLanguagePreference: shared.LangEn,
 			Status:                    shared.AttorneyStatusActive,

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -81,10 +81,10 @@ func Validate(lpa shared.LpaInit) []shared.FieldError {
 
 func countAttorneys(as []shared.Attorney, ts []shared.TrustCorporation) (actives, replacements int) {
 	for _, a := range as {
-		switch a.Status {
-		case shared.AttorneyStatusActive:
+		switch a.AppointmentType {
+		case shared.AppointmentTypeOriginal:
 			actives++
-		case shared.AttorneyStatusReplacement:
+		case shared.AppointmentTypeReplacement:
 			replacements++
 		}
 	}
@@ -125,6 +125,7 @@ func validateAttorney(prefix string, attorney shared.Attorney) []shared.FieldErr
 		validate.Date(fmt.Sprintf("%s/dateOfBirth", prefix), attorney.DateOfBirth),
 		validate.Address(fmt.Sprintf("%s/address", prefix), attorney.Address),
 		validate.IsValid(fmt.Sprintf("%s/status", prefix), attorney.Status),
+		validate.IsValid(fmt.Sprintf("%s/appointmentType", prefix), attorney.AppointmentType),
 		validate.IsValid(fmt.Sprintf("%s/channel", prefix), attorney.Channel),
 		validate.IfElse(attorney.Channel == shared.ChannelOnline,
 			validate.Required(fmt.Sprintf("%s/email", prefix), attorney.Email),

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -81,10 +81,10 @@ func Validate(lpa shared.LpaInit) []shared.FieldError {
 
 func countAttorneys(as []shared.Attorney, ts []shared.TrustCorporation) (actives, replacements int) {
 	for _, a := range as {
-		switch a.AppointmentType {
-		case shared.AppointmentTypeOriginal:
+		switch a.Status {
+		case shared.AttorneyStatusActive:
 			actives++
-		case shared.AppointmentTypeReplacement:
+		case shared.AttorneyStatusReplacement:
 			replacements++
 		}
 	}

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -125,7 +125,6 @@ func validateAttorney(prefix string, attorney shared.Attorney) []shared.FieldErr
 		validate.Date(fmt.Sprintf("%s/dateOfBirth", prefix), attorney.DateOfBirth),
 		validate.Address(fmt.Sprintf("%s/address", prefix), attorney.Address),
 		validate.IsValid(fmt.Sprintf("%s/status", prefix), attorney.Status),
-		validate.IsValid(fmt.Sprintf("%s/appointmentType", prefix), attorney.AppointmentType),
 		validate.IsValid(fmt.Sprintf("%s/channel", prefix), attorney.Channel),
 		validate.IfElse(attorney.Channel == shared.ChannelOnline,
 			validate.Required(fmt.Sprintf("%s/email", prefix), attorney.Email),

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -26,11 +26,12 @@ func makeAttorney() shared.Attorney {
 			FirstNames: "Sharonda",
 			LastName:   "Graciani",
 		},
-		Address:     validAddress,
-		Email:       "some@example.com",
-		Channel:     shared.ChannelOnline,
-		DateOfBirth: newDate("1977-10-30"),
-		Status:      shared.AttorneyStatusActive,
+		Address:         validAddress,
+		AppointmentType: shared.AppointmentTypeOriginal,
+		Email:           "some@example.com",
+		Channel:         shared.ChannelOnline,
+		DateOfBirth:     newDate("1977-10-30"),
+		Status:          shared.AttorneyStatusActive,
 	}
 }
 
@@ -41,11 +42,12 @@ func makeReplacementAttorney() shared.Attorney {
 			FirstNames: "Sharonda",
 			LastName:   "Graciani",
 		},
-		Address:     validAddress,
-		Email:       "some@example.com",
-		Channel:     shared.ChannelOnline,
-		DateOfBirth: newDate("1977-10-30"),
-		Status:      shared.AttorneyStatusReplacement,
+		Address:         validAddress,
+		AppointmentType: shared.AppointmentTypeReplacement,
+		Email:           "some@example.com",
+		Channel:         shared.ChannelOnline,
+		DateOfBirth:     newDate("1977-10-30"),
+		Status:          shared.AttorneyStatusReplacement,
 	}
 }
 
@@ -103,9 +105,9 @@ func TestCountAttorneys(t *testing.T) {
 	assert.Equal(t, 0, replacements)
 
 	actives, replacements = countAttorneys([]shared.Attorney{
-		{Status: shared.AttorneyStatusReplacement},
-		{Status: shared.AttorneyStatusActive},
-		{Status: shared.AttorneyStatusReplacement},
+		{AppointmentType: shared.AppointmentTypeReplacement},
+		{AppointmentType: shared.AppointmentTypeOriginal},
+		{AppointmentType: shared.AppointmentTypeReplacement},
 	}, []shared.TrustCorporation{
 		{Status: shared.AttorneyStatusReplacement},
 		{Status: shared.AttorneyStatusActive},
@@ -122,6 +124,7 @@ func TestValidateAttorneyEmpty(t *testing.T) {
 		{Source: "/test/firstNames", Detail: "field is required"},
 		{Source: "/test/lastName", Detail: "field is required"},
 		{Source: "/test/status", Detail: "field is required"},
+		{Source: "/test/appointmentType", Detail: "field is required"},
 		{Source: "/test/address/line1", Detail: "field is required"},
 		{Source: "/test/address/country", Detail: "field is required"},
 		{Source: "/test/address/country", Detail: "must be a valid ISO-3166-1 country code"},

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -124,7 +124,6 @@ func TestValidateAttorneyEmpty(t *testing.T) {
 		{Source: "/test/firstNames", Detail: "field is required"},
 		{Source: "/test/lastName", Detail: "field is required"},
 		{Source: "/test/status", Detail: "field is required"},
-		{Source: "/test/appointmentType", Detail: "field is required"},
 		{Source: "/test/address/line1", Detail: "field is required"},
 		{Source: "/test/address/country", Detail: "field is required"},
 		{Source: "/test/address/country", Detail: "must be a valid ISO-3166-1 country code"},

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -105,9 +105,9 @@ func TestCountAttorneys(t *testing.T) {
 	assert.Equal(t, 0, replacements)
 
 	actives, replacements = countAttorneys([]shared.Attorney{
-		{AppointmentType: shared.AppointmentTypeReplacement},
-		{AppointmentType: shared.AppointmentTypeOriginal},
-		{AppointmentType: shared.AppointmentTypeReplacement},
+		{Status: shared.AttorneyStatusReplacement},
+		{Status: shared.AttorneyStatusActive},
+		{Status: shared.AttorneyStatusReplacement},
 	}, []shared.TrustCorporation{
 		{Status: shared.AttorneyStatusReplacement},
 		{Status: shared.AttorneyStatusActive},

--- a/mock-apigw/main.go
+++ b/mock-apigw/main.go
@@ -148,6 +148,7 @@ func handlePactState(r *http.Request) error {
 					"lastName": "Vallar",
 					"dateOfBirth": "2001-01-17",
 					"status": "active",
+					"appointmentType": "original",
 					"address": {
 						"line1": "71 South Western Terrace",
 						"town": "Milton",


### PR DESCRIPTION
# Purpose

Ticket to split the attorney status into two fields, the status and the appointment type (original and replacement)

Fixes (VEGA-2656)
