### PR TITLE
Remove target event bus from default env config

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,9 +9,7 @@
         "arn:aws:iam::493907465011:role/operator",
         "arn:aws:iam::493907465011:role/lpa-store-ci"
       ],
-      "target_event_buses": [
-        "arn:aws:events:eu-west-1:288342028542:event-bus/dev-poas"
-      ]
+      "target_event_buses": []
     },
     "development": {
       "account_id": "493907465011",


### PR DESCRIPTION
# Purpose

The "default" environment configuration is used by pop-up environments. It should not have a target event bus because there's no valid bus to send to.

The existing config (sending to the Sirius dev event bus) is invalid because Sirius can't then read the LPA back from the store: it tries—and fails—to use the dev LPA Store, not the pop-up.

Fixes VEGA-2790 #patch

## Approach

Removed target event bus from config
