### PR TITLE
Update logic for Restrictions and Conditions/images

### DIFF
--- a/docs/schemas/2024-10/donor-details.json
+++ b/docs/schemas/2024-10/donor-details.json
@@ -174,6 +174,9 @@
       "type": "string",
       "enum": ["option-a", "option-b"]
     },
+    "restrictionsAndConditions": {
+      "type": "string"
+    },
     "signedAt": {
       "type": "string",
       "format": "date-time"
@@ -194,17 +197,10 @@
   "if": {
     "required": ["channel"],
     "properties": {
-      "channel": { "const": "online" }
+      "channel": { "const": "paper" }
     }
   },
   "then": {
-    "properties": {
-      "restrictionsAndConditions": {
-        "type": "string"
-      }
-    }
-  },
-  "else": {
     "properties": {
       "restrictionsAndConditionsImages": {
         "type": "array",


### PR DESCRIPTION
# Purpose

Rather than having one or the other, always allow `restrictionsAndConditions` and only allow `restrictionsAndConditionsImages` if it's a paper LPA.

This is necessary because severances will cause images on a paper LPA to be replaced by text instead.

#minor
