### PR TITLE
VEGA-2658 Remove replacement attorney status, add inactive status to schemas

### DIFF
--- a/docs/schemas/2024-10/donor-details.json
+++ b/docs/schemas/2024-10/donor-details.json
@@ -300,7 +300,7 @@
         },
         "status": {
           "type": "string",
-          "enum": ["active", "replacement", "removed"]
+          "enum": ["active", "inactive", "removed"]
         },
         "channel": {
           "type": "string",
@@ -340,7 +340,7 @@
         },
         "status": {
           "type": "string",
-          "enum": ["active", "replacement", "removed"]
+          "enum": ["active", "inactive", "removed"]
         },
         "channel": {
           "type": "string",

--- a/docs/schemas/2024-10/lpa.json
+++ b/docs/schemas/2024-10/lpa.json
@@ -46,7 +46,7 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "inactive", "replacement", "removed"]
+            "enum": ["active", "inactive", "removed"]
           },
           "appointmentType": {
             "type": "string",

--- a/internal/shared/person.go
+++ b/internal/shared/person.go
@@ -56,14 +56,13 @@ func (e Channel) IsValid() bool {
 type AttorneyStatus string
 
 const (
-	AttorneyStatusActive      = AttorneyStatus("active")
-	AttorneyStatusInactive    = AttorneyStatus("inactive")
-	AttorneyStatusReplacement = AttorneyStatus("replacement")
-	AttorneyStatusRemoved     = AttorneyStatus("removed")
+	AttorneyStatusActive   = AttorneyStatus("active")
+	AttorneyStatusInactive = AttorneyStatus("inactive")
+	AttorneyStatusRemoved  = AttorneyStatus("removed")
 )
 
 func (a AttorneyStatus) IsValid() bool {
-	return a == AttorneyStatusActive || a == AttorneyStatusReplacement || a == AttorneyStatusRemoved || a == AttorneyStatusInactive
+	return a == AttorneyStatusActive || a == AttorneyStatusRemoved || a == AttorneyStatusInactive
 }
 
 type AppointmentType string

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -81,19 +81,25 @@ func Validate(lpa shared.LpaInit) []shared.FieldError {
 
 func countAttorneys(as []shared.Attorney, ts []shared.TrustCorporation) (actives, replacements int) {
 	for _, a := range as {
-		switch a.AppointmentType {
-		case shared.AppointmentTypeOriginal:
+		if a.Status == shared.AttorneyStatusRemoved {
+			continue
+		}
+
+		if a.Status == shared.AttorneyStatusActive {
 			actives++
-		case shared.AppointmentTypeReplacement:
+		} else if a.Status == shared.AttorneyStatusInactive && a.AppointmentType == shared.AppointmentTypeReplacement {
 			replacements++
 		}
 	}
 
 	for _, t := range ts {
-		switch t.AppointmentType {
-		case shared.AppointmentTypeOriginal:
+		if t.Status == shared.AttorneyStatusRemoved {
+			continue
+		}
+
+		if t.Status == shared.AttorneyStatusActive {
 			actives++
-		case shared.AppointmentTypeReplacement:
+		} else if t.Status == shared.AttorneyStatusInactive && t.AppointmentType == shared.AppointmentTypeReplacement {
 			replacements++
 		}
 	}

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -47,7 +47,7 @@ func makeReplacementAttorney() shared.Attorney {
 		Email:           "some@example.com",
 		Channel:         shared.ChannelOnline,
 		DateOfBirth:     newDate("1977-10-30"),
-		Status:          shared.AttorneyStatusReplacement,
+		Status:          shared.AttorneyStatusInactive,
 	}
 }
 
@@ -106,12 +106,27 @@ func TestCountAttorneys(t *testing.T) {
 	assert.Equal(t, 0, replacements)
 
 	actives, replacements = countAttorneys([]shared.Attorney{
-		{AppointmentType: shared.AppointmentTypeReplacement},
-		{AppointmentType: shared.AppointmentTypeOriginal},
-		{AppointmentType: shared.AppointmentTypeReplacement},
+		{
+			Status:          shared.AttorneyStatusInactive,
+			AppointmentType: shared.AppointmentTypeReplacement,
+		},
+		{
+			Status:          shared.AttorneyStatusActive,
+			AppointmentType: shared.AppointmentTypeOriginal,
+		},
+		{
+			Status:          shared.AttorneyStatusInactive,
+			AppointmentType: shared.AppointmentTypeReplacement,
+		},
 	}, []shared.TrustCorporation{
-		{AppointmentType: shared.AppointmentTypeReplacement},
-		{AppointmentType: shared.AppointmentTypeOriginal},
+		{
+			Status:          shared.AttorneyStatusInactive,
+			AppointmentType: shared.AppointmentTypeReplacement,
+		},
+		{
+			Status:          shared.AttorneyStatusActive,
+			AppointmentType: shared.AppointmentTypeOriginal,
+		},
 	})
 	assert.Equal(t, 2, actives)
 	assert.Equal(t, 3, replacements)

--- a/lambda/update/attorney_opt_out_test.go
+++ b/lambda/update/attorney_opt_out_test.go
@@ -39,13 +39,13 @@ func TestAttorneyOptOutApply(t *testing.T) {
 				},
 			},
 		},
-		"successful apply to replacement": {
+		"successful apply to inactive": {
 			lpa: &shared.Lpa{
 				Status: shared.LpaStatusInProgress,
 				LpaInit: shared.LpaInit{
 					Attorneys: []shared.Attorney{
 						{Person: shared.Person{UID: "a"}, Status: shared.AttorneyStatusActive},
-						{Person: shared.Person{UID: "b"}, Status: shared.AttorneyStatusReplacement},
+						{Person: shared.Person{UID: "b"}, Status: shared.AttorneyStatusInactive},
 						{Person: shared.Person{UID: "c"}, Status: shared.AttorneyStatusActive},
 					},
 				},

--- a/lambda/update/trust_corporation_opt_out_test.go
+++ b/lambda/update/trust_corporation_opt_out_test.go
@@ -39,13 +39,13 @@ func TestTrustCorporationOptOutApply(t *testing.T) {
 				},
 			},
 		},
-		"successful apply to replacement": {
+		"successful apply to inactive": {
 			lpa: &shared.Lpa{
 				Status: shared.LpaStatusInProgress,
 				LpaInit: shared.LpaInit{
 					TrustCorporations: []shared.TrustCorporation{
 						{UID: "a", Status: shared.AttorneyStatusActive},
-						{UID: "b", Status: shared.AttorneyStatusReplacement},
+						{UID: "b", Status: shared.AttorneyStatusInactive},
 						{UID: "c", Status: shared.AttorneyStatusActive},
 					},
 				},


### PR DESCRIPTION
 [VEGA-2658](https://opgtransform.atlassian.net/browse/VEGA-2658?atlOrigin=eyJpIjoiMzc5MThmYjdiMDE0NGUwNDk3ODk2OTQ0YzFkNzRhMTMiLCJwIjoiaiJ9) Update count attorneys func to return active attorneys and inactive replacement attorneys. Fix tests and refactor status tests.

# Purpose

Remove the `replacement` attorney status.

## Approach

Active attorneys are now either active original attorneys or active replacement attorneys. The old concept of replacement attorneys are now inactive replacement attorneys.

## Learning

n/a


[VEGA-2658]: https://opgtransform.atlassian.net/browse/VEGA-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ