### PR TITLE
VEGA-2793 Change Certificate Provider details

### DIFF
--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -181,6 +181,25 @@ func validateDonor(donor *DonorCorrection) func(p *parse.Parser) []shared.FieldE
 	}
 }
 
+func validateCertificateProvider(certificateProvider *CertificateProviderCorrection) func(p *parse.Parser) []shared.FieldError {
+	return func(p *parse.Parser) []shared.FieldError {
+		return p.
+			Field("/firstNames", &certificateProvider.FirstNames, parse.Validate(func() []shared.FieldError {
+				return validate.Required("", certificateProvider.FirstNames)
+			}), parse.Optional()).
+			Field("/lastName", &certificateProvider.LastName, parse.Validate(func() []shared.FieldError {
+				return validate.Required("", certificateProvider.LastName)
+			}), parse.Optional()).
+			Prefix("/address", validateAddress(&certificateProvider.Address), parse.Optional()).
+			Field("/email", &certificateProvider.Email, parse.Optional()).
+			Field("/phone", &certificateProvider.Phone, parse.Optional()).
+			Field("/signedAt", &certificateProvider.SignedAt, parse.Validate(func() []shared.FieldError {
+				return validate.Time("", certificateProvider.SignedAt)
+			}), parse.Optional()).
+			Consumed()
+	}
+}
+
 func validateAddress(address *shared.Address) func(p *parse.Parser) []shared.FieldError {
 	return func(p *parse.Parser) []shared.FieldError {
 		return p.

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -203,9 +203,7 @@ func validateCertificateProvider(certificateProvider *CertificateProviderCorrect
 			Prefix("/address", validateAddress(&certificateProvider.Address), parse.Optional()).
 			Field("/email", &certificateProvider.Email, parse.Optional()).
 			Field("/phone", &certificateProvider.Phone, parse.Optional()).
-			Field("/signedAt", &certificateProvider.SignedAt, parse.Validate(func() []shared.FieldError {
-				return validate.Time("", certificateProvider.SignedAt)
-			}), parse.Optional()).
+			Field("/signedAt", &certificateProvider.SignedAt, parse.Optional()).
 			Consumed()
 	}
 }

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -73,6 +73,8 @@ func (c Correction) Apply(lpa *shared.Lpa) []shared.FieldError {
 	c.Attorney.Apply(lpa)
 	lpa.SignedAt = c.LPASignedAt
 
+	c.CertificateProvider.Apply(lpa)
+
 	return nil
 }
 
@@ -109,6 +111,13 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 	data.Donor.Email = lpa.LpaInit.Donor.Email
 	data.LPASignedAt = lpa.LpaInit.SignedAt
 
+	data.CertificateProvider.FirstNames = lpa.LpaInit.CertificateProvider.FirstNames
+	data.CertificateProvider.LastName = lpa.LpaInit.CertificateProvider.LastName
+	data.CertificateProvider.Address = lpa.LpaInit.CertificateProvider.Address
+	data.CertificateProvider.Email = lpa.LpaInit.CertificateProvider.Email
+	data.CertificateProvider.Phone = lpa.LpaInit.CertificateProvider.Phone
+	data.CertificateProvider.SignedAt = lpa.LpaInit.SignedAt
+
 	errors := parse.Changes(changes).
 		Prefix("/donor", validateDonor(&data.Donor), parse.Optional()).
 		Field(signedAt, &data.LPASignedAt, parse.Validate(func() []shared.FieldError {
@@ -137,6 +146,7 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 				}).
 				Consumed()
 		}, parse.Optional()).
+		Prefix("/certificateProvider", validateCertificateProvider(&data.CertificateProvider), parse.Optional()).
 		Consumed()
 
 	return data, errors

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -21,7 +21,7 @@ type CertificateProviderCorrection struct {
 	Address    shared.Address
 	Email      string
 	Phone      string
-	SignedAt   *time.Time
+	SignedAt   time.Time
 }
 
 func (cpr CertificateProviderCorrection) Apply(lpa *shared.Lpa) {
@@ -30,7 +30,7 @@ func (cpr CertificateProviderCorrection) Apply(lpa *shared.Lpa) {
 	lpa.CertificateProvider.Address = cpr.Address
 	lpa.CertificateProvider.Email = cpr.Email
 	lpa.CertificateProvider.Phone = cpr.Phone
-	lpa.CertificateProvider.SignedAt = cpr.SignedAt
+	lpa.CertificateProvider.SignedAt = &cpr.SignedAt
 }
 
 type DonorCorrection struct {
@@ -116,7 +116,10 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 	data.CertificateProvider.Address = lpa.LpaInit.CertificateProvider.Address
 	data.CertificateProvider.Email = lpa.LpaInit.CertificateProvider.Email
 	data.CertificateProvider.Phone = lpa.LpaInit.CertificateProvider.Phone
-	data.CertificateProvider.SignedAt = lpa.LpaInit.CertificateProvider.SignedAt
+
+	if lpa.LpaInit.CertificateProvider.SignedAt != nil {
+		data.CertificateProvider.SignedAt = *lpa.LpaInit.CertificateProvider.SignedAt
+	}
 
 	errors := parse.Changes(changes).
 		Prefix("/donor", validateDonor(&data.Donor), parse.Optional()).

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -65,6 +65,15 @@ func (c Correction) Apply(lpa *shared.Lpa) []shared.FieldError {
 		return []shared.FieldError{{Source: source, Detail: "The attorney signed at date cannot be changed for online LPA"}}
 	}
 
+	if !c.CertificateProvider.SignedAt.IsZero() &&
+		!c.CertificateProvider.SignedAt.Equal(*lpa.CertificateProvider.SignedAt) &&
+		lpa.Channel == shared.ChannelOnline {
+		return []shared.FieldError{{
+			Source: "/certificateProvider" + signedAt,
+			Detail: "The Certificate Provider Signed on date cannot be changed for online LPAs",
+		}}
+	}
+
 	if lpa.Status == shared.LpaStatusRegistered {
 		return []shared.FieldError{{Source: "/type", Detail: "Cannot make corrections to a Registered LPA"}}
 	}

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -21,7 +21,7 @@ type CertificateProviderCorrection struct {
 	Address    shared.Address
 	Email      string
 	Phone      string
-	SignedAt   time.Time
+	SignedAt   *time.Time
 }
 
 func (cpr CertificateProviderCorrection) Apply(lpa *shared.Lpa) {
@@ -30,7 +30,7 @@ func (cpr CertificateProviderCorrection) Apply(lpa *shared.Lpa) {
 	lpa.CertificateProvider.Address = cpr.Address
 	lpa.CertificateProvider.Email = cpr.Email
 	lpa.CertificateProvider.Phone = cpr.Phone
-	lpa.CertificateProvider.SignedAt = &cpr.SignedAt
+	lpa.CertificateProvider.SignedAt = cpr.SignedAt
 }
 
 type DonorCorrection struct {
@@ -116,7 +116,7 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 	data.CertificateProvider.Address = lpa.LpaInit.CertificateProvider.Address
 	data.CertificateProvider.Email = lpa.LpaInit.CertificateProvider.Email
 	data.CertificateProvider.Phone = lpa.LpaInit.CertificateProvider.Phone
-	data.CertificateProvider.SignedAt = lpa.LpaInit.SignedAt
+	data.CertificateProvider.SignedAt = lpa.LpaInit.CertificateProvider.SignedAt
 
 	errors := parse.Changes(changes).
 		Prefix("/donor", validateDonor(&data.Donor), parse.Optional()).

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -9,9 +9,28 @@ import (
 )
 
 type Correction struct {
-	Donor       DonorCorrection
-	Attorney    AttorneyCorrection
-	LPASignedAt time.Time
+	Donor               DonorCorrection
+	Attorney            AttorneyCorrection
+	CertificateProvider CertificateProviderCorrection
+	LPASignedAt         time.Time
+}
+
+type CertificateProviderCorrection struct {
+	FirstNames string
+	LastName   string
+	Address    shared.Address
+	Email      string
+	Phone      string
+	SignedAt   time.Time
+}
+
+func (cpr CertificateProviderCorrection) Apply(lpa *shared.Lpa) {
+	lpa.CertificateProvider.FirstNames = cpr.FirstNames
+	lpa.CertificateProvider.LastName = cpr.LastName
+	lpa.CertificateProvider.Address = cpr.Address
+	lpa.CertificateProvider.Email = cpr.Email
+	lpa.CertificateProvider.Phone = cpr.Phone
+	lpa.CertificateProvider.SignedAt = &cpr.SignedAt
 }
 
 type DonorCorrection struct {

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -224,7 +224,7 @@ func TestCorrectionApplyForCertificateProvider(t *testing.T) {
 		Address:    shared.Address{},
 		Email:      "Lynn.Christiansen@example.com",
 		Phone:      "01003 19993",
-		SignedAt:   &yesterday,
+		SignedAt:   yesterday,
 	}
 
 	correction := Correction{
@@ -239,7 +239,7 @@ func TestCorrectionApplyForCertificateProvider(t *testing.T) {
 	assert.Equal(t, correction.CertificateProvider.Address, lpa.CertificateProvider.Address)
 	assert.Equal(t, correction.CertificateProvider.Email, lpa.CertificateProvider.Email)
 	assert.Equal(t, correction.CertificateProvider.Phone, lpa.CertificateProvider.Phone)
-	assert.Equal(t, correction.CertificateProvider.SignedAt, lpa.CertificateProvider.SignedAt)
+	assert.Equal(t, correction.CertificateProvider.SignedAt, *lpa.CertificateProvider.SignedAt)
 }
 
 func TestValidateCorrection(t *testing.T) {

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -369,6 +369,7 @@ func TestValidateCorrection(t *testing.T) {
 			errors: []shared.FieldError{
 				{Source: "/changes/0/new", Detail: "must be a valid ISO-3166-1 country code"},
 				{Source: "/changes/1/new", Detail: "must be a valid ISO-3166-1 country code"},
+				{Source: "/changes/2/new", Detail: "must be a valid ISO-3166-1 country code"},
 			},
 		},
 	}

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -194,6 +194,54 @@ func TestCorrectionAttorneySignedAtChannel(t *testing.T) {
 	assert.Equal(t, errors, []shared.FieldError{{Source: "/attorney/0/signedAt", Detail: "The attorney signed at date cannot be changed for online LPA"}})
 }
 
+func TestCorrectionApplyForCertificateProvider(t *testing.T) {
+	yesterday := time.Now().Add(-24 * time.Hour)
+
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			CertificateProvider: shared.CertificateProvider{
+				Person: shared.Person{
+					FirstNames: "Branson",
+					LastName:   "Conn",
+				},
+				Address: shared.Address{
+					Line1:    "9 Kutch Meadows",
+					Line2:    "Cummerata",
+					Town:     "West Blick",
+					Postcode: "YX97 3HZ",
+					Country:  "UK",
+				},
+				Email:    "Branson.Conn@example.com",
+				Phone:    "01977 67513",
+				SignedAt: &yesterday,
+			},
+		},
+	}
+
+	certificateProviderCorrection := CertificateProviderCorrection{
+		FirstNames: "Lynn",
+		LastName:   "Christiansen",
+		Address:    shared.Address{},
+		Email:      "Lynn.Christiansen@example.com",
+		Phone:      "01003 19993",
+		SignedAt:   yesterday,
+	}
+
+	correction := Correction{
+		CertificateProvider: certificateProviderCorrection,
+	}
+
+	errors := correction.Apply(lpa)
+
+	assert.Empty(t, errors)
+	assert.Equal(t, correction.CertificateProvider.FirstNames, lpa.CertificateProvider.FirstNames)
+	assert.Equal(t, correction.CertificateProvider.LastName, lpa.CertificateProvider.LastName)
+	assert.Equal(t, correction.CertificateProvider.Address, lpa.CertificateProvider.Address)
+	assert.Equal(t, correction.CertificateProvider.Email, lpa.CertificateProvider.Email)
+	assert.Equal(t, correction.CertificateProvider.Phone, lpa.CertificateProvider.Phone)
+	assert.Equal(t, correction.CertificateProvider.SignedAt, lpa.CertificateProvider.SignedAt)
+}
+
 func TestValidateCorrection(t *testing.T) {
 	now := time.Now()
 	const fieldRequired = "field is required"

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -224,7 +224,7 @@ func TestCorrectionApplyForCertificateProvider(t *testing.T) {
 		Address:    shared.Address{},
 		Email:      "Lynn.Christiansen@example.com",
 		Phone:      "01003 19993",
-		SignedAt:   yesterday,
+		SignedAt:   &yesterday,
 	}
 
 	correction := Correction{
@@ -310,17 +310,34 @@ func TestValidateCorrection(t *testing.T) {
 				},
 			},
 		},
+		"valid certificate provider update": {
+			changes: []shared.Change{
+				{Key: "/certificateProvider/firstNames", New: json.RawMessage(`"Trinity"`), Old: jsonNull},
+				{Key: "/certificateProvider/lastName", New: json.RawMessage(`"Monahan"`), Old: jsonNull},
+				{Key: "/certificateProvider/email", New: json.RawMessage(`"Trinity.Monahan@example.com"`), Old: jsonNull},
+				{Key: "/certificateProvider/phone", New: json.RawMessage(`"01697 233 415"`), Old: jsonNull},
+				{Key: "/certificateProvider/signedAt", New: json.RawMessage(`"` + now.Format(time.RFC3339Nano) + `"`), Old: jsonNull},
+			},
+			lpa: &shared.Lpa{
+				LpaInit: shared.LpaInit{
+					CertificateProvider: shared.CertificateProvider{},
+				},
+			},
+		},
 		"missing required fields": {
 			changes: []shared.Change{
 				{Key: "/donor/firstNames", New: jsonNull, Old: jsonNull},
 				{Key: "/donor/lastName", New: jsonNull, Old: jsonNull},
 				{Key: "/attorneys/0/firstNames", New: jsonNull, Old: jsonNull},
 				{Key: "/attorneys/0/lastName", New: jsonNull, Old: jsonNull},
+				{Key: "/certificateProvider/firstNames", New: jsonNull, Old: jsonNull},
+				{Key: "/certificateProvider/lastName", New: jsonNull, Old: jsonNull},
 			},
 			lpa: &shared.Lpa{
 				LpaInit: shared.LpaInit{
-					Donor:     shared.Donor{},
-					Attorneys: []shared.Attorney{{}},
+					Donor:               shared.Donor{},
+					Attorneys:           []shared.Attorney{{}},
+					CertificateProvider: shared.CertificateProvider{},
 				},
 			},
 			errors: []shared.FieldError{
@@ -328,12 +345,15 @@ func TestValidateCorrection(t *testing.T) {
 				{Source: "/changes/1/new", Detail: fieldRequired},
 				{Source: "/changes/2/new", Detail: fieldRequired},
 				{Source: "/changes/3/new", Detail: fieldRequired},
+				{Source: "/changes/4/new", Detail: fieldRequired},
+				{Source: "/changes/5/new", Detail: fieldRequired},
 			},
 		},
 		"invalid country": {
 			changes: []shared.Change{
 				{Key: "/donor/address/country", New: json.RawMessage(`"United Kingdom"`), Old: jsonNull},
 				{Key: "/attorneys/0/address/country", New: json.RawMessage(`"United Kingdom"`), Old: jsonNull},
+				{Key: "/certificateProvider/address/country", New: json.RawMessage(`"United Kingdom"`), Old: jsonNull},
 			},
 			lpa: &shared.Lpa{
 				LpaInit: shared.LpaInit{
@@ -341,6 +361,9 @@ func TestValidateCorrection(t *testing.T) {
 						Address: shared.Address{},
 					},
 					Attorneys: []shared.Attorney{{}},
+					CertificateProvider: shared.CertificateProvider{
+						Address: shared.Address{},
+					},
 				},
 			},
 			errors: []shared.FieldError{

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -248,6 +248,31 @@ func TestCorrectionApplyForCertificateProvider(t *testing.T) {
 	assert.Equal(t, correction.CertificateProvider.SignedAt, *lpa.CertificateProvider.SignedAt)
 }
 
+func TestCorrectionApplyForCertificateProviderSignedAtChannel(t *testing.T) {
+	now := time.Now()
+	yesterday := now.Add(-24 * time.Hour)
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			Channel: "online",
+			CertificateProvider: shared.CertificateProvider{
+				SignedAt: &yesterday,
+			},
+		},
+	}
+
+	correction := Correction{
+		CertificateProvider: CertificateProviderCorrection{
+			SignedAt: now,
+		},
+	}
+	errors := correction.Apply(lpa)
+
+	assert.Equal(t, errors, []shared.FieldError{{
+		Source: "/certificateProvider/signedAt",
+		Detail: "The Certificate Provider Signed on date cannot be changed for online LPAs",
+	}})
+}
+
 func TestValidateCorrection(t *testing.T) {
 	now := time.Now()
 	const fieldRequired = "field is required"

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -195,6 +195,7 @@ func TestCorrectionAttorneySignedAtChannel(t *testing.T) {
 }
 
 func TestCorrectionApplyForCertificateProvider(t *testing.T) {
+	twoDaysAgo := time.Now().Add(-48 * time.Hour)
 	yesterday := time.Now().Add(-24 * time.Hour)
 
 	lpa := &shared.Lpa{
@@ -213,7 +214,7 @@ func TestCorrectionApplyForCertificateProvider(t *testing.T) {
 				},
 				Email:    "Branson.Conn@example.com",
 				Phone:    "01977 67513",
-				SignedAt: &yesterday,
+				SignedAt: &twoDaysAgo,
 			},
 		},
 	}
@@ -221,10 +222,15 @@ func TestCorrectionApplyForCertificateProvider(t *testing.T) {
 	certificateProviderCorrection := CertificateProviderCorrection{
 		FirstNames: "Lynn",
 		LastName:   "Christiansen",
-		Address:    shared.Address{},
-		Email:      "Lynn.Christiansen@example.com",
-		Phone:      "01003 19993",
-		SignedAt:   yesterday,
+		Address: shared.Address{
+			Line1:    "653 Prosacco Avenue",
+			Town:     "Long Larkin",
+			Postcode: "RC18 6RZ",
+			Country:  "UK",
+		},
+		Email:    "Lynn.Christiansen@example.com",
+		Phone:    "01003 19993",
+		SignedAt: yesterday,
 	}
 
 	correction := Correction{


### PR DESCRIPTION
# Purpose

[VEGA-2793](https://opgtransform.atlassian.net/browse/VEGA-2793?atlOrigin=eyJpIjoiODhjYTAwZjI3Zjk4NGMzMGIwNzllN2MzNDIwYTZhZGYiLCJwIjoiaiJ9) Adds support for Certificate Provider corrections.

## Approach

Updated `corrections.go`, similar to how we update the donor and attorneys.

## Learning

n/a

[VEGA-2793]: https://opgtransform.atlassian.net/browse/VEGA-2793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ