### PR TITLE
Refactor validation so it works better for both use cases

### DIFF
--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,11 +1,8 @@
 package validate
 
 import (
-	"fmt"
 	"regexp"
-	"time"
 
-	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 )
 
@@ -43,79 +40,13 @@ func IfFunc(ok bool, fn func() []shared.FieldError) []shared.FieldError {
 	return nil
 }
 
-func Required(source string, value string) []shared.FieldError {
-	return If(value == "", []shared.FieldError{{Source: source, Detail: "field is required"}})
-}
-
-func Empty(source string, value string) []shared.FieldError {
-	return If(value != "", []shared.FieldError{{Source: source, Detail: "field must not be provided"}})
-}
-
-func UUID(source string, value string) []shared.FieldError {
-	if value == "" {
-		return []shared.FieldError{{Source: source, Detail: "field is required"}}
+func WithSource(source string, val any, validators ...Validator) (errs []shared.FieldError) {
+	for _, validator := range validators {
+		msg := validator.Valid(val)
+		if msg != "" {
+			errs = append(errs, shared.FieldError{Source: source, Detail: msg})
+		}
 	}
 
-	if uuid.Validate(value) != nil {
-		return []shared.FieldError{{Source: source, Detail: "invalid format"}}
-	}
-
-	return nil
-}
-
-func Date(source string, date shared.Date) []shared.FieldError {
-	if date.IsMalformed {
-		return []shared.FieldError{{Source: source, Detail: "invalid format"}}
-	}
-
-	if date.IsZero() {
-		return []shared.FieldError{{Source: source, Detail: "field is required"}}
-	}
-
-	return nil
-}
-
-func Time(source string, t interface{ IsZero() bool }) []shared.FieldError {
-	return If(t == (*time.Time)(nil) || t.IsZero(), []shared.FieldError{{Source: source, Detail: "field is required"}})
-}
-
-func OptionalTime(source string, t *time.Time) []shared.FieldError {
-	if t == nil {
-		return nil
-	}
-
-	return If(t.IsZero(), []shared.FieldError{{Source: source, Detail: "must be a valid datetime"}})
-}
-
-func Address(prefix string, address shared.Address) []shared.FieldError {
-	return All(
-		Required(fmt.Sprintf("%s/line1", prefix), address.Line1),
-		Required(fmt.Sprintf("%s/country", prefix), address.Country),
-		Country(fmt.Sprintf("%s/country", prefix), address.Country),
-	)
-}
-
-func Country(source string, country string) []shared.FieldError {
-	return If(!countryCodeRe.MatchString(country), []shared.FieldError{{Source: source, Detail: "must be a valid ISO-3166-1 country code"}})
-}
-
-type isValid interface {
-	~string
-	IsValid() bool
-}
-
-func IsValid[V isValid](source string, v V) []shared.FieldError {
-	if e := Required(source, string(v)); e != nil {
-		return e
-	}
-
-	if !v.IsValid() {
-		return []shared.FieldError{{Source: source, Detail: "invalid value"}}
-	}
-
-	return nil
-}
-
-func Unset(source string, v interface{ Unset() bool }) []shared.FieldError {
-	return If(!v.Unset(), []shared.FieldError{{Source: source, Detail: "field must not be provided"}})
+	return errs
 }

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -2,7 +2,6 @@ package validate
 
 import (
 	"testing"
-	"time"
 
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 	"github.com/stretchr/testify/assert"
@@ -44,81 +43,4 @@ func TestIfElse(t *testing.T) {
 
 	assert.Equal(t, errsA, IfElse(true, errsA, errsB))
 	assert.Equal(t, errsB, IfElse(false, errsA, errsB))
-}
-
-func TestRequired(t *testing.T) {
-	assert.Nil(t, Required("a", "a"))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field is required"}}, Required("a", ""))
-}
-
-func TestEmpty(t *testing.T) {
-	assert.Nil(t, Empty("a", ""))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field must not be provided"}}, Empty("a", "a"))
-}
-
-func TestUUID(t *testing.T) {
-	assert.Nil(t, UUID("a", "dc487ebb-b39d-45ed-bb6a-7f950fd355c9"))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "invalid format"}}, UUID("a", "dc487ebb-b39d-45ed-bb6a-7f950fd355c"))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field is required"}}, UUID("a", ""))
-}
-
-func TestDate(t *testing.T) {
-	assert.Nil(t, Date("a", newDate("2010-01-02")))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "invalid format"}}, Date("a", shared.Date{IsMalformed: true}))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field is required"}}, Date("a", shared.Date{}))
-}
-
-func TestTime(t *testing.T) {
-	assert.Nil(t, Time("a", time.Now()))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field is required"}}, Time("a", time.Time{}))
-}
-
-func TestOptionalTime(t *testing.T) {
-	now := time.Now()
-	assert.Nil(t, OptionalTime("a", &now))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "must be a valid datetime"}}, OptionalTime("a", &time.Time{}))
-	assert.Nil(t, OptionalTime("a", nil))
-}
-
-func TestAddressEmpty(t *testing.T) {
-	address := shared.Address{}
-	errors := Address("/test", address)
-
-	assert.Contains(t, errors, shared.FieldError{Source: "/test/line1", Detail: "field is required"})
-	assert.Contains(t, errors, shared.FieldError{Source: "/test/country", Detail: "field is required"})
-}
-
-func TestAddressValid(t *testing.T) {
-	errors := Address("/test", validAddress)
-
-	assert.Empty(t, errors)
-}
-
-func TestAddressInvalidCountry(t *testing.T) {
-	invalidAddress := shared.Address{
-		Line1:   "123 Main St",
-		Country: "United Kingdom",
-	}
-	errors := Address("/test", invalidAddress)
-
-	assert.Contains(t, errors, shared.FieldError{Source: "/test/country", Detail: "must be a valid ISO-3166-1 country code"})
-}
-
-type testIsValid string
-
-func (t testIsValid) IsValid() bool { return string(t) == "ok" }
-
-func TestIsValid(t *testing.T) {
-	assert.Nil(t, IsValid("a", testIsValid("ok")))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field is required"}}, IsValid("a", testIsValid("")))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "invalid value"}}, IsValid("a", testIsValid("x")))
-}
-
-type testUnset bool
-
-func (t testUnset) Unset() bool { return bool(t) }
-
-func TestUnset(t *testing.T) {
-	assert.Nil(t, Unset("a", testUnset(true)))
-	assert.Equal(t, []shared.FieldError{{Source: "a", Detail: "field must not be provided"}}, Unset("a", testUnset(false)))
 }

--- a/internal/validate/validators.go
+++ b/internal/validate/validators.go
@@ -1,0 +1,239 @@
+package validate
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+)
+
+const (
+	msgRequired    = "field is required"
+	msgType        = "unexpected type"
+	msgNotProvided = "field must not be provided"
+	msgInvalid     = "invalid value"
+	msgFormat      = "invalid format"
+	msgCountryCode = "must be a valid ISO-3166-1 country code"
+	msgDateTime    = "must be a valid datetime"
+)
+
+type Validator interface {
+	Valid(val any) string
+}
+
+type NotEmptyValidator struct{}
+
+func (v NotEmptyValidator) Valid(val any) string {
+	switch v := val.(type) {
+	case *string:
+		if *v == "" {
+			return msgRequired
+		} else {
+			return ""
+		}
+	case string:
+		if v == "" {
+			return msgRequired
+		} else {
+			return ""
+		}
+	case *time.Time:
+		if v == nil || v.IsZero() {
+			return msgRequired
+		} else {
+			return ""
+		}
+	case time.Time:
+		if v.IsZero() {
+			return msgRequired
+		} else {
+			return ""
+		}
+	}
+
+	return msgType
+}
+
+func NotEmpty() Validator {
+	return NotEmptyValidator{}
+}
+
+type EmptyValidator struct{}
+
+func (v EmptyValidator) Valid(val any) string {
+	switch v := val.(type) {
+	case *string:
+		if *v == "" {
+			return ""
+		} else {
+			return msgNotProvided
+		}
+	case string:
+		if v == "" {
+			return ""
+		} else {
+			return msgNotProvided
+		}
+	case *time.Time:
+		if v == nil || v.IsZero() {
+			return ""
+		} else {
+			return msgNotProvided
+		}
+	case time.Time:
+		if v.IsZero() {
+			return ""
+		} else {
+			return msgNotProvided
+		}
+	}
+
+	return msgType
+}
+
+func Empty() Validator {
+	return EmptyValidator{}
+}
+
+type ValidValidator struct{}
+
+func (v ValidValidator) Valid(val any) string {
+	if fmt.Sprint(val) == "" {
+		return msgRequired
+	}
+
+	enum, ok := val.(interface{ IsValid() bool })
+	if !ok {
+		return msgType
+	}
+
+	if !enum.IsValid() {
+		return msgInvalid
+	}
+
+	return ""
+}
+
+func Valid() Validator {
+	return ValidValidator{}
+}
+
+type UnsetValidator struct{}
+
+func (v UnsetValidator) Valid(val any) string {
+	unset, ok := val.(interface{ Unset() bool })
+	if !ok {
+		return msgType
+	}
+
+	if !unset.Unset() {
+		return msgNotProvided
+	}
+
+	return ""
+}
+
+func Unset() Validator {
+	return UnsetValidator{}
+}
+
+type UUIDValidator struct{}
+
+func (v UUIDValidator) Valid(val any) string {
+	str, ok := val.(string)
+	if !ok {
+		return msgType
+	}
+
+	if str == "" {
+		return msgRequired
+	}
+
+	if uuid.Validate(str) != nil {
+		return msgFormat
+	}
+
+	return ""
+}
+
+func UUID() Validator {
+	return UUIDValidator{}
+}
+
+type DateValidator struct{}
+
+func (v DateValidator) Valid(val any) string {
+	switch v := val.(type) {
+	case shared.Date:
+		if v.IsMalformed {
+			return msgFormat
+		}
+
+		if v.IsZero() {
+			return msgRequired
+		}
+
+		return ""
+	case *shared.Date:
+		if v.IsMalformed {
+			return msgFormat
+		}
+
+		if v.IsZero() {
+			return msgRequired
+		}
+
+		return ""
+	}
+
+	return msgType
+}
+
+func Date() Validator {
+	return DateValidator{}
+}
+
+type CountryValidator struct{}
+
+func (v CountryValidator) Valid(val any) string {
+	switch v := val.(type) {
+	case string:
+		if !countryCodeRe.MatchString(v) {
+			return msgCountryCode
+		} else {
+			return ""
+		}
+	case *string:
+		if !countryCodeRe.MatchString(*v) {
+			return msgCountryCode
+		} else {
+			return ""
+		}
+	}
+
+	return msgType
+}
+
+func Country() Validator {
+	return CountryValidator{}
+}
+
+type OptionalTimeValidator struct{}
+
+func (v OptionalTimeValidator) Valid(val any) string {
+	t, ok := val.(*time.Time)
+	if !ok {
+		return msgType
+	}
+
+	if t != nil && t.IsZero() {
+		return msgDateTime
+	}
+
+	return ""
+}
+
+func OptionalTime() Validator {
+	return OptionalTimeValidator{}
+}

--- a/internal/validate/validators_test.go
+++ b/internal/validate/validators_test.go
@@ -1,0 +1,66 @@
+package validate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotEmpty(t *testing.T) {
+	assert.Equal(t, "", NotEmpty().Valid("a"))
+	assert.Equal(t, "field is required", NotEmpty().Valid(""))
+	assert.Equal(t, "", NotEmpty().Valid(time.Now()))
+	assert.Equal(t, "field is required", NotEmpty().Valid(time.Time{}))
+}
+
+func TestEmpty(t *testing.T) {
+	assert.Equal(t, "", Empty().Valid(""))
+	assert.Equal(t, "field must not be provided", Empty().Valid("a"))
+	assert.Equal(t, "", Empty().Valid(time.Time{}))
+	assert.Equal(t, "field must not be provided", Empty().Valid(time.Now()))
+}
+
+func TestUUID(t *testing.T) {
+	assert.Equal(t, "", UUID().Valid("dc487ebb-b39d-45ed-bb6a-7f950fd355c9"))
+	assert.Equal(t, "invalid format", UUID().Valid("dc487ebb-b39d-45ed-bb6a-7f950fd355c"))
+	assert.Equal(t, "field is required", UUID().Valid(""))
+}
+
+func TestDate(t *testing.T) {
+	assert.Equal(t, "", Date().Valid(newDate("2010-01-02")))
+	assert.Equal(t, "invalid format", Date().Valid(shared.Date{IsMalformed: true}))
+	assert.Equal(t, "field is required", Date().Valid(shared.Date{}))
+}
+
+func TestOptionalTime(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, "", OptionalTime().Valid(&now))
+	assert.Equal(t, "must be a valid datetime", OptionalTime().Valid(&time.Time{}))
+	assert.Equal(t, "", OptionalTime().Valid((*time.Time)(nil)))
+}
+
+func TestAddressInvalidCountry(t *testing.T) {
+	assert.Equal(t, "", Country().Valid("GB"))
+	assert.Equal(t, "must be a valid ISO-3166-1 country code", Country().Valid("United Kingdom"))
+}
+
+type testIsValid string
+
+func (t testIsValid) IsValid() bool { return string(t) == "ok" }
+
+func TestIsValid(t *testing.T) {
+	assert.Equal(t, "", Valid().Valid(testIsValid("ok")))
+	assert.Equal(t, "field is required", Valid().Valid(testIsValid("")))
+	assert.Equal(t, "invalid value", Valid().Valid(testIsValid("x")))
+}
+
+type testUnset bool
+
+func (t testUnset) Unset() bool { return bool(t) }
+
+func TestUnset(t *testing.T) {
+	assert.Equal(t, "", Unset().Valid(testUnset(true)))
+	assert.Equal(t, "field must not be provided", Unset().Valid(testUnset(false)))
+}

--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -7,76 +7,83 @@ import (
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
 )
 
+func validateAddress(prefix string, address shared.Address) []shared.FieldError {
+	return validate.All(
+		validate.WithSource(prefix+"/line1", address.Line1, validate.NotEmpty()),
+		validate.WithSource(prefix+"/country", address.Country, validate.NotEmpty(), validate.Country()),
+	)
+}
+
 func Validate(lpa shared.LpaInit) []shared.FieldError {
 	activeAttorneyCount, replacementAttorneyCount := countAttorneys(lpa.Attorneys, lpa.TrustCorporations)
 
 	return validate.All(
-		validate.IsValid("/lpaType", lpa.LpaType),
-		validate.IsValid("/channel", lpa.Channel),
-		validate.IsValid("/language", lpa.Language),
-		validate.UUID("/donor/uid", lpa.Donor.UID),
-		validate.Required("/donor/firstNames", lpa.Donor.FirstNames),
-		validate.Required("/donor/lastName", lpa.Donor.LastName),
-		validate.Date("/donor/dateOfBirth", lpa.Donor.DateOfBirth),
-		validate.Address("/donor/address", lpa.Donor.Address),
-		validate.IsValid("/donor/contactLanguagePreference", lpa.Donor.ContactLanguagePreference),
+		validate.WithSource("/lpaType", lpa.LpaType, validate.Valid()),
+		validate.WithSource("/channel", lpa.Channel, validate.Valid()),
+		validate.WithSource("/language", lpa.Language, validate.Valid()),
+		validate.WithSource("/donor/uid", lpa.Donor.UID, validate.UUID()),
+		validate.WithSource("/donor/firstNames", lpa.Donor.FirstNames, validate.NotEmpty()),
+		validate.WithSource("/donor/lastName", lpa.Donor.LastName, validate.NotEmpty()),
+		validate.WithSource("/donor/dateOfBirth", lpa.Donor.DateOfBirth, validate.Date()),
+		validateAddress("/donor/address", lpa.Donor.Address),
+		validate.WithSource("/donor/contactLanguagePreference", lpa.Donor.ContactLanguagePreference, validate.Valid()),
 		validate.IfFunc(lpa.Donor.IdentityCheck != nil, func() []shared.FieldError {
 			return validate.All(
-				validate.Time("/donor/identityCheck/checkedAt", lpa.Donor.IdentityCheck.CheckedAt),
-				validate.IsValid("/donor/identityCheck/type", lpa.Donor.IdentityCheck.Type))
+				validate.WithSource("/donor/identityCheck/checkedAt", lpa.Donor.IdentityCheck.CheckedAt, validate.NotEmpty()),
+				validate.WithSource("/donor/identityCheck/type", lpa.Donor.IdentityCheck.Type, validate.Valid()))
 		}),
-		validate.UUID("/certificateProvider/uid", lpa.CertificateProvider.UID),
-		validate.Required("/certificateProvider/firstNames", lpa.CertificateProvider.FirstNames),
-		validate.Required("/certificateProvider/lastName", lpa.CertificateProvider.LastName),
-		validate.Address("/certificateProvider/address", lpa.CertificateProvider.Address),
-		validate.IsValid("/certificateProvider/channel", lpa.CertificateProvider.Channel),
+		validate.WithSource("/certificateProvider/uid", lpa.CertificateProvider.UID, validate.UUID()),
+		validate.WithSource("/certificateProvider/firstNames", lpa.CertificateProvider.FirstNames, validate.NotEmpty()),
+		validate.WithSource("/certificateProvider/lastName", lpa.CertificateProvider.LastName, validate.NotEmpty()),
+		validateAddress("/certificateProvider/address", lpa.CertificateProvider.Address),
+		validate.WithSource("/certificateProvider/channel", lpa.CertificateProvider.Channel, validate.Valid()),
 		validate.IfElse(lpa.CertificateProvider.Channel == shared.ChannelOnline,
-			validate.Required("/certificateProvider/email", lpa.CertificateProvider.Email),
-			validate.Empty("/certificateProvider/email", lpa.CertificateProvider.Email)),
-		validate.Required("/certificateProvider/phone", lpa.CertificateProvider.Phone),
+			validate.WithSource("/certificateProvider/email", lpa.CertificateProvider.Email, validate.NotEmpty()),
+			validate.WithSource("/certificateProvider/email", lpa.CertificateProvider.Email, validate.Empty())),
+		validate.WithSource("/certificateProvider/phone", lpa.CertificateProvider.Phone, validate.NotEmpty()),
 		validateAttorneys("/attorneys", lpa.Attorneys),
 		validateTrustCorporations("/trustCorporations", lpa.TrustCorporations),
 		validate.IfFunc(lpa.AuthorisedSignatory != nil, func() []shared.FieldError {
 			return validate.All(
-				validate.Required("/authorisedSignatory/uid", lpa.AuthorisedSignatory.UID),
-				validate.Required("/authorisedSignatory/firstNames", lpa.AuthorisedSignatory.FirstNames),
-				validate.Required("/authorisedSignatory/lastName", lpa.AuthorisedSignatory.LastName))
+				validate.WithSource("/authorisedSignatory/uid", lpa.AuthorisedSignatory.UID, validate.NotEmpty()),
+				validate.WithSource("/authorisedSignatory/firstNames", lpa.AuthorisedSignatory.FirstNames, validate.NotEmpty()),
+				validate.WithSource("/authorisedSignatory/lastName", lpa.AuthorisedSignatory.LastName, validate.NotEmpty()))
 		}),
 		validate.IfFunc(lpa.IndependentWitness != nil, func() []shared.FieldError {
 			return validate.All(
-				validate.Required("/independentWitness/uid", lpa.IndependentWitness.UID),
-				validate.Required("/independentWitness/firstNames", lpa.IndependentWitness.FirstNames),
-				validate.Required("/independentWitness/lastName", lpa.IndependentWitness.LastName),
-				validate.Required("/independentWitness/phone", lpa.IndependentWitness.Phone),
-				validate.Address("/independentWitness/address", lpa.IndependentWitness.Address),
-				validate.Time("/witnessedByIndependentWitnessAt", lpa.WitnessedByIndependentWitnessAt))
+				validate.WithSource("/independentWitness/uid", lpa.IndependentWitness.UID, validate.NotEmpty()),
+				validate.WithSource("/independentWitness/firstNames", lpa.IndependentWitness.FirstNames, validate.NotEmpty()),
+				validate.WithSource("/independentWitness/lastName", lpa.IndependentWitness.LastName, validate.NotEmpty()),
+				validate.WithSource("/independentWitness/phone", lpa.IndependentWitness.Phone, validate.NotEmpty()),
+				validateAddress("/independentWitness/address", lpa.IndependentWitness.Address),
+				validate.WithSource("/witnessedByIndependentWitnessAt", lpa.WitnessedByIndependentWitnessAt, validate.NotEmpty()))
 		}),
 		validate.IfElse(activeAttorneyCount > 1,
-			validate.IsValid("/howAttorneysMakeDecisions", lpa.HowAttorneysMakeDecisions),
-			validate.Unset("/howAttorneysMakeDecisions", lpa.HowAttorneysMakeDecisions)),
+			validate.WithSource("/howAttorneysMakeDecisions", lpa.HowAttorneysMakeDecisions, validate.Valid()),
+			validate.WithSource("/howAttorneysMakeDecisions", lpa.HowAttorneysMakeDecisions, validate.Unset())),
 		validate.IfElse(lpa.HowAttorneysMakeDecisions == shared.HowMakeDecisionsJointlyForSomeSeverallyForOthers,
-			validate.Required("/howAttorneysMakeDecisionsDetails", lpa.HowAttorneysMakeDecisionsDetails),
-			validate.Empty("/howAttorneysMakeDecisionsDetails", lpa.HowAttorneysMakeDecisionsDetails)),
+			validate.WithSource("/howAttorneysMakeDecisionsDetails", lpa.HowAttorneysMakeDecisionsDetails, validate.NotEmpty()),
+			validate.WithSource("/howAttorneysMakeDecisionsDetails", lpa.HowAttorneysMakeDecisionsDetails, validate.Empty())),
 		validate.If(replacementAttorneyCount > 0 && lpa.HowAttorneysMakeDecisions == shared.HowMakeDecisionsJointlyAndSeverally,
-			validate.IsValid("/howReplacementAttorneysStepIn", lpa.HowReplacementAttorneysStepIn)),
+			validate.WithSource("/howReplacementAttorneysStepIn", lpa.HowReplacementAttorneysStepIn, validate.Valid())),
 		validate.IfElse(lpa.HowReplacementAttorneysStepIn == shared.HowStepInAnotherWay,
-			validate.Required("/howReplacementAttorneysStepInDetails", lpa.HowReplacementAttorneysStepInDetails),
-			validate.Empty("/howReplacementAttorneysStepInDetails", lpa.HowReplacementAttorneysStepInDetails)),
+			validate.WithSource("/howReplacementAttorneysStepInDetails", lpa.HowReplacementAttorneysStepInDetails, validate.NotEmpty()),
+			validate.WithSource("/howReplacementAttorneysStepInDetails", lpa.HowReplacementAttorneysStepInDetails, validate.Empty())),
 		validate.IfElse(replacementAttorneyCount > 1 && (lpa.HowReplacementAttorneysStepIn == shared.HowStepInAllCanNoLongerAct || lpa.HowAttorneysMakeDecisions != shared.HowMakeDecisionsJointlyAndSeverally),
-			validate.IsValid("/howReplacementAttorneysMakeDecisions", lpa.HowReplacementAttorneysMakeDecisions),
-			validate.Unset("/howReplacementAttorneysMakeDecisions", lpa.HowReplacementAttorneysMakeDecisions)),
+			validate.WithSource("/howReplacementAttorneysMakeDecisions", lpa.HowReplacementAttorneysMakeDecisions, validate.Valid()),
+			validate.WithSource("/howReplacementAttorneysMakeDecisions", lpa.HowReplacementAttorneysMakeDecisions, validate.Unset())),
 		validate.IfElse(lpa.HowReplacementAttorneysMakeDecisions == shared.HowMakeDecisionsJointlyForSomeSeverallyForOthers,
-			validate.Required("/howReplacementAttorneysMakeDecisionsDetails", lpa.HowReplacementAttorneysMakeDecisionsDetails),
-			validate.Empty("/howReplacementAttorneysMakeDecisionsDetails", lpa.HowReplacementAttorneysMakeDecisionsDetails)),
+			validate.WithSource("/howReplacementAttorneysMakeDecisionsDetails", lpa.HowReplacementAttorneysMakeDecisionsDetails, validate.NotEmpty()),
+			validate.WithSource("/howReplacementAttorneysMakeDecisionsDetails", lpa.HowReplacementAttorneysMakeDecisionsDetails, validate.Empty())),
 		validate.If(lpa.LpaType == shared.LpaTypePersonalWelfare, validate.All(
-			validate.IsValid("/lifeSustainingTreatmentOption", lpa.LifeSustainingTreatmentOption),
-			validate.Unset("/whenTheLpaCanBeUsed", lpa.WhenTheLpaCanBeUsed))),
+			validate.WithSource("/lifeSustainingTreatmentOption", lpa.LifeSustainingTreatmentOption, validate.Valid()),
+			validate.WithSource("/whenTheLpaCanBeUsed", lpa.WhenTheLpaCanBeUsed, validate.Unset()))),
 		validate.If(lpa.LpaType == shared.LpaTypePropertyAndAffairs, validate.All(
-			validate.IsValid("/whenTheLpaCanBeUsed", lpa.WhenTheLpaCanBeUsed),
-			validate.Unset("/lifeSustainingTreatmentOption", lpa.LifeSustainingTreatmentOption))),
-		validate.Time("/signedAt", lpa.SignedAt),
-		validate.Time("/witnessedByCertificateProviderAt", lpa.WitnessedByCertificateProviderAt),
-		validate.OptionalTime("/certificateProviderNotRelatedConfirmedAt", lpa.CertificateProviderNotRelatedConfirmedAt),
+			validate.WithSource("/whenTheLpaCanBeUsed", lpa.WhenTheLpaCanBeUsed, validate.Valid()),
+			validate.WithSource("/lifeSustainingTreatmentOption", lpa.LifeSustainingTreatmentOption, validate.Unset()))),
+		validate.WithSource("/signedAt", lpa.SignedAt, validate.NotEmpty()),
+		validate.WithSource("/witnessedByCertificateProviderAt", lpa.WitnessedByCertificateProviderAt, validate.NotEmpty()),
+		validate.WithSource("/certificateProviderNotRelatedConfirmedAt", lpa.CertificateProviderNotRelatedConfirmedAt, validate.OptionalTime()),
 	)
 }
 
@@ -126,17 +133,17 @@ func validateAttorneys(prefix string, attorneys []shared.Attorney) []shared.Fiel
 
 func validateAttorney(prefix string, attorney shared.Attorney) []shared.FieldError {
 	return validate.All(
-		validate.UUID(fmt.Sprintf("%s/uid", prefix), attorney.UID),
-		validate.Required(fmt.Sprintf("%s/firstNames", prefix), attorney.FirstNames),
-		validate.Required(fmt.Sprintf("%s/lastName", prefix), attorney.LastName),
-		validate.Date(fmt.Sprintf("%s/dateOfBirth", prefix), attorney.DateOfBirth),
-		validate.Address(fmt.Sprintf("%s/address", prefix), attorney.Address),
-		validate.IsValid(fmt.Sprintf("%s/status", prefix), attorney.Status),
-		validate.IsValid(fmt.Sprintf("%s/channel", prefix), attorney.Channel),
-		validate.IsValid(fmt.Sprintf("%s/appointmentType", prefix), attorney.AppointmentType),
+		validate.WithSource(fmt.Sprintf("%s/uid", prefix), attorney.UID, validate.UUID()),
+		validate.WithSource(fmt.Sprintf("%s/firstNames", prefix), attorney.FirstNames, validate.NotEmpty()),
+		validate.WithSource(fmt.Sprintf("%s/lastName", prefix), attorney.LastName, validate.NotEmpty()),
+		validate.WithSource(fmt.Sprintf("%s/dateOfBirth", prefix), attorney.DateOfBirth, validate.Date()),
+		validateAddress(fmt.Sprintf("%s/address", prefix), attorney.Address),
+		validate.WithSource(fmt.Sprintf("%s/status", prefix), attorney.Status, validate.Valid()),
+		validate.WithSource(fmt.Sprintf("%s/channel", prefix), attorney.Channel, validate.Valid()),
+		validate.WithSource(fmt.Sprintf("%s/appointmentType", prefix), attorney.AppointmentType, validate.Valid()),
 		validate.IfElse(attorney.Channel == shared.ChannelOnline,
-			validate.Required(fmt.Sprintf("%s/email", prefix), attorney.Email),
-			validate.Empty(fmt.Sprintf("%s/email", prefix), attorney.Email)),
+			validate.WithSource(fmt.Sprintf("%s/email", prefix), attorney.Email, validate.NotEmpty()),
+			validate.WithSource(fmt.Sprintf("%s/email", prefix), attorney.Email, validate.Empty())),
 	)
 }
 
@@ -154,15 +161,15 @@ func validateTrustCorporations(prefix string, trustCorporations []shared.TrustCo
 
 func validateTrustCorporation(prefix string, trustCorporation shared.TrustCorporation) []shared.FieldError {
 	return validate.All(
-		validate.UUID(fmt.Sprintf("%s/uid", prefix), trustCorporation.UID),
-		validate.Required(fmt.Sprintf("%s/name", prefix), trustCorporation.Name),
-		validate.Required(fmt.Sprintf("%s/companyNumber", prefix), trustCorporation.CompanyNumber),
-		validate.Address(fmt.Sprintf("%s/address", prefix), trustCorporation.Address),
-		validate.IsValid(fmt.Sprintf("%s/status", prefix), trustCorporation.Status),
-		validate.IsValid(fmt.Sprintf("%s/channel", prefix), trustCorporation.Channel),
-		validate.IsValid(fmt.Sprintf("%s/appointmentType", prefix), trustCorporation.AppointmentType),
+		validate.WithSource(fmt.Sprintf("%s/uid", prefix), trustCorporation.UID, validate.UUID()),
+		validate.WithSource(fmt.Sprintf("%s/name", prefix), trustCorporation.Name, validate.NotEmpty()),
+		validate.WithSource(fmt.Sprintf("%s/companyNumber", prefix), trustCorporation.CompanyNumber, validate.NotEmpty()),
+		validateAddress(fmt.Sprintf("%s/address", prefix), trustCorporation.Address),
+		validate.WithSource(fmt.Sprintf("%s/status", prefix), trustCorporation.Status, validate.Valid()),
+		validate.WithSource(fmt.Sprintf("%s/channel", prefix), trustCorporation.Channel, validate.Valid()),
+		validate.WithSource(fmt.Sprintf("%s/appointmentType", prefix), trustCorporation.AppointmentType, validate.Valid()),
 		validate.IfElse(trustCorporation.Channel == shared.ChannelOnline,
-			validate.Required(fmt.Sprintf("%s/email", prefix), trustCorporation.Email),
-			validate.Empty(fmt.Sprintf("%s/email", prefix), trustCorporation.Email)),
+			validate.WithSource(fmt.Sprintf("%s/email", prefix), trustCorporation.Email, validate.NotEmpty()),
+			validate.WithSource(fmt.Sprintf("%s/email", prefix), trustCorporation.Email, validate.Empty())),
 	)
 }

--- a/lambda/update/attorney_opt_out.go
+++ b/lambda/update/attorney_opt_out.go
@@ -31,7 +31,7 @@ func validateAttorneyOptOut(update shared.Update) (AttorneyOptOut, []shared.Fiel
 
 	author := update.Author.Details()
 
-	if errs := validate.UUID("/author", author.UID); len(errs) > 0 {
+	if errs := validate.WithSource("/author", author.UID, validate.UUID()); len(errs) > 0 {
 		return AttorneyOptOut{}, errs
 	}
 

--- a/lambda/update/attorney_sign.go
+++ b/lambda/update/attorney_sign.go
@@ -54,15 +54,9 @@ func validateAttorneySign(changes []shared.Change, lpa *shared.Lpa) (AttorneySig
 
 					return p.
 						Field("/mobile", &data.Mobile).
-						Field("/signedAt", &data.SignedAt, parse.Validate(func() []shared.FieldError {
-							return validate.Time("", data.SignedAt)
-						})).
-						Field("/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(func() []shared.FieldError {
-							return validate.IsValid("", data.ContactLanguagePreference)
-						})).
-						Field("/channel", &data.Channel, parse.Validate(func() []shared.FieldError {
-							return validate.IsValid("", data.Channel)
-						}), parse.Optional()).
+						Field("/signedAt", &data.SignedAt, parse.Validate(validate.NotEmpty())).
+						Field("/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid())).
+						Field("/channel", &data.Channel, parse.Validate(validate.Valid()), parse.Optional()).
 						Field("/email", &data.Email, parse.Optional()).
 						Consumed()
 				}).

--- a/lambda/update/certificate_provider_sign.go
+++ b/lambda/update/certificate_provider_sign.go
@@ -50,23 +50,13 @@ func validateCertificateProviderSign(changes []shared.Change, lpa *shared.Lpa) (
 				Field("/line3", &data.Address.Line3, parse.Optional()).
 				Field("/town", &data.Address.Town).
 				Field("/postcode", &data.Address.Postcode, parse.Optional()).
-				Field("/country", &data.Address.Country, parse.Validate(func() []shared.FieldError {
-					return validate.Country("", data.Address.Country)
-				})).
+				Field("/country", &data.Address.Country, parse.Validate(validate.Country())).
 				Consumed()
 		}, parse.Optional()).
-		Field("/certificateProvider/signedAt", &data.SignedAt, parse.Validate(func() []shared.FieldError {
-			return validate.Time("", data.SignedAt)
-		})).
-		Field("/certificateProvider/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(func() []shared.FieldError {
-			return validate.IsValid("", data.ContactLanguagePreference)
-		})).
-		Field("/certificateProvider/email", &data.Email, parse.Validate(func() []shared.FieldError {
-			return validate.Required("", data.Email)
-		}), parse.Optional()).
-		Field("/certificateProvider/channel", &data.Channel, parse.Validate(func() []shared.FieldError {
-			return validate.IsValid("", data.Channel)
-		}), parse.Optional()).
+		Field("/certificateProvider/signedAt", &data.SignedAt, parse.Validate(validate.NotEmpty())).
+		Field("/certificateProvider/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid())).
+		Field("/certificateProvider/email", &data.Email, parse.Validate(validate.NotEmpty()), parse.Optional()).
+		Field("/certificateProvider/channel", &data.Channel, parse.Validate(validate.Valid()), parse.Optional()).
 		Consumed()
 
 	return data, errors

--- a/lambda/update/confirm_identity.go
+++ b/lambda/update/confirm_identity.go
@@ -40,12 +40,8 @@ func validateConfirmIdentity(prefix string, actor idccActor, ic *shared.Identity
 			idcc.IdentityCheck = ic
 
 			return p.
-				Field("/type", &ic.Type, parse.Validate(func() []shared.FieldError {
-					return validate.IsValid("", ic.Type)
-				})).
-				Field("/checkedAt", &ic.CheckedAt, parse.Validate(func() []shared.FieldError {
-					return validate.Time("", ic.CheckedAt)
-				})).
+				Field("/type", &ic.Type, parse.Validate(validate.Valid())).
+				Field("/checkedAt", &ic.CheckedAt, parse.Validate(validate.NotEmpty())).
 				Consumed()
 		}).
 		Consumed()

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
 	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
-	"strconv"
-	"time"
 )
 
 type Correction struct {
@@ -132,9 +133,7 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 
 	errors := parse.Changes(changes).
 		Prefix("/donor", validateDonor(&data.Donor), parse.Optional()).
-		Field(signedAt, &data.LPASignedAt, parse.Validate(func() []shared.FieldError {
-			return validate.Time("", data.LPASignedAt)
-		}), parse.Optional()).
+		Field(signedAt, &data.LPASignedAt, parse.Validate(validate.NotEmpty()), parse.Optional()).
 		Prefix("/attorneys", func(p *parse.Parser) []shared.FieldError {
 			return p.
 				Each(func(i int, p *parse.Parser) []shared.FieldError {
@@ -166,37 +165,23 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 
 func validateAttorney(attorney *AttorneyCorrection, p *parse.Parser) []shared.FieldError {
 	return p.
-		Field("/firstNames", &attorney.FirstNames, parse.Validate(func() []shared.FieldError {
-			return validate.Required("", attorney.FirstNames)
-		}), parse.Optional()).
-		Field("/lastName", &attorney.LastName, parse.Validate(func() []shared.FieldError {
-			return validate.Required("", attorney.LastName)
-		}), parse.Optional()).
-		Field("/dateOfBirth", &attorney.Dob, parse.Validate(func() []shared.FieldError {
-			return validate.Date("", attorney.Dob)
-		}), parse.Optional()).
+		Field("/firstNames", &attorney.FirstNames, parse.Validate(validate.NotEmpty()), parse.Optional()).
+		Field("/lastName", &attorney.LastName, parse.Validate(validate.NotEmpty()), parse.Optional()).
+		Field("/dateOfBirth", &attorney.Dob, parse.Validate(validate.Date()), parse.Optional()).
 		Field("/email", &attorney.Email, parse.Optional()).
 		Field("/mobile", &attorney.Mobile, parse.Optional()).
 		Prefix("/address", validateAddress(&attorney.Address), parse.Optional()).
-		Field(signedAt, &attorney.SignedAt, parse.Validate(func() []shared.FieldError {
-			return validate.Time("", attorney.SignedAt)
-		}), parse.Optional()).
+		Field(signedAt, &attorney.SignedAt, parse.Validate(validate.NotEmpty()), parse.Optional()).
 		Consumed()
 }
 
 func validateDonor(donor *DonorCorrection) func(p *parse.Parser) []shared.FieldError {
 	return func(p *parse.Parser) []shared.FieldError {
 		return p.
-			Field("/firstNames", &donor.FirstNames, parse.Validate(func() []shared.FieldError {
-				return validate.Required("", donor.FirstNames)
-			}), parse.Optional()).
-			Field("/lastName", &donor.LastName, parse.Validate(func() []shared.FieldError {
-				return validate.Required("", donor.LastName)
-			}), parse.Optional()).
+			Field("/firstNames", &donor.FirstNames, parse.Validate(validate.NotEmpty()), parse.Optional()).
+			Field("/lastName", &donor.LastName, parse.Validate(validate.NotEmpty()), parse.Optional()).
 			Field("/otherNamesKnownBy", &donor.OtherNamesKnownBy, parse.Optional()).
-			Field("/dateOfBirth", &donor.DateOfBirth, parse.Validate(func() []shared.FieldError {
-				return validate.Date("", donor.DateOfBirth)
-			}), parse.Optional()).
+			Field("/dateOfBirth", &donor.DateOfBirth, parse.Validate(validate.Date()), parse.Optional()).
 			Prefix("/address", validateAddress(&donor.Address), parse.Optional()).
 			Field("/email", &donor.Email, parse.Optional()).
 			Consumed()
@@ -206,12 +191,8 @@ func validateDonor(donor *DonorCorrection) func(p *parse.Parser) []shared.FieldE
 func validateCertificateProvider(certificateProvider *CertificateProviderCorrection) func(p *parse.Parser) []shared.FieldError {
 	return func(p *parse.Parser) []shared.FieldError {
 		return p.
-			Field("/firstNames", &certificateProvider.FirstNames, parse.Validate(func() []shared.FieldError {
-				return validate.Required("", certificateProvider.FirstNames)
-			}), parse.Optional()).
-			Field("/lastName", &certificateProvider.LastName, parse.Validate(func() []shared.FieldError {
-				return validate.Required("", certificateProvider.LastName)
-			}), parse.Optional()).
+			Field("/firstNames", &certificateProvider.FirstNames, parse.Validate(validate.NotEmpty()), parse.Optional()).
+			Field("/lastName", &certificateProvider.LastName, parse.Validate(validate.NotEmpty()), parse.Optional()).
 			Prefix("/address", validateAddress(&certificateProvider.Address), parse.Optional()).
 			Field("/email", &certificateProvider.Email, parse.Optional()).
 			Field("/phone", &certificateProvider.Phone, parse.Optional()).
@@ -228,9 +209,7 @@ func validateAddress(address *shared.Address) func(p *parse.Parser) []shared.Fie
 			Field("/line3", &address.Line3, parse.Optional()).
 			Field("/town", &address.Town, parse.Optional()).
 			Field("/postcode", &address.Postcode, parse.Optional()).
-			Field("/country", &address.Country, parse.Validate(func() []shared.FieldError {
-				return validate.Country("", address.Country)
-			}), parse.Optional()).
+			Field("/country", &address.Country, parse.Validate(validate.Country()), parse.Optional()).
 			Consumed()
 	}
 }

--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -42,15 +42,12 @@ func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 }
 
 func validateOpgChangeStatus(changes []shared.Change, lpa *shared.Lpa) (OpgChangeStatus, []shared.FieldError) {
-
 	var data OpgChangeStatus
 
 	data.Status = lpa.Status
 
 	errors := parse.Changes(changes).
-		Field("/status", &data.Status, parse.Validate(func() []shared.FieldError {
-			return validate.IsValid("", data.Status)
-		})).
+		Field("/status", &data.Status, parse.Validate(validate.Valid())).
 		Consumed()
 
 	return data, errors

--- a/lambda/update/trust_corporation_opt_out.go
+++ b/lambda/update/trust_corporation_opt_out.go
@@ -31,7 +31,7 @@ func validateTrustCorporationOptOut(update shared.Update) (TrustCorporationOptOu
 
 	author := update.Author.Details()
 
-	if errs := validate.UUID("/author", author.UID); len(errs) > 0 {
+	if errs := validate.WithSource("/author", author.UID, validate.UUID()); len(errs) > 0 {
 		return TrustCorporationOptOut{}, errs
 	}
 

--- a/lambda/update/trust_corporation_sign.go
+++ b/lambda/update/trust_corporation_sign.go
@@ -51,13 +51,9 @@ func validateTrustCorporationSign(changes []shared.Change, lpa *shared.Lpa) (Tru
 
 					return each.
 						Field("/mobile", &data.Mobile).
-						Field("/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(func() []shared.FieldError {
-							return validate.IsValid("", data.ContactLanguagePreference)
-						})).
+						Field("/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid())).
 						Field("/email", &data.Email, parse.Optional()).
-						Field("/channel", &data.Channel, parse.Validate(func() []shared.FieldError {
-							return validate.IsValid("", data.Channel)
-						}), parse.Optional()).
+						Field("/channel", &data.Channel, parse.Validate(validate.Valid()), parse.Optional()).
 						Prefix("/signatories", func(prefix *parse.Parser) []shared.FieldError {
 							return prefix.
 								Each(func(i int, each *parse.Parser) []shared.FieldError {


### PR DESCRIPTION
Pros:
- less repetition when used with `update/parse`

Cons:
- have to deal with `type` and `*type` in the validators