### PR TITLE
VEGA-2822 : Implementation of attorney status change functionality

### DIFF
--- a/docs/change-attorneys.json
+++ b/docs/change-attorneys.json
@@ -1,0 +1,15 @@
+{
+    "type": "CHANGE_ATTORNEYS",
+    "changes": [
+        {
+            "key": "/attorneys/0/status",
+            "new": "removed",
+            "old": "active"
+        },
+        {
+            "key": "/attorneys/1/status",
+            "new": "active",
+            "old": "inactive"
+        }
+    ]
+}

--- a/lambda/update/change_attorneys.go
+++ b/lambda/update/change_attorneys.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
+	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
+	"strconv"
+)
+
+type ChangeAttorney struct {
+	ChangeAttorneyStatus []ChangeAttorneyStatus
+}
+
+type ChangeAttorneyStatus struct {
+	Index  *int
+	Status shared.AttorneyStatus
+}
+
+func (a ChangeAttorney) Apply(lpa *shared.Lpa) []shared.FieldError {
+	for _, changeAttorneyStatus := range a.ChangeAttorneyStatus {
+		source := "/attorneys/" + strconv.Itoa(*changeAttorneyStatus.Index) + "/status"
+		if changeAttorneyStatus.Status == shared.AttorneyStatusRemoved && lpa.Attorneys[*changeAttorneyStatus.Index].Status == shared.AttorneyStatusInactive {
+			return []shared.FieldError{{Source: source, Detail: "An inactive attorney cannot be removed"}}
+		}
+
+		if changeAttorneyStatus.Status == shared.AttorneyStatusInactive && lpa.Attorneys[*changeAttorneyStatus.Index].Status == shared.AttorneyStatusActive {
+			return []shared.FieldError{{Source: source, Detail: "An active attorney cannot be made inactive"}}
+		}
+
+		if changeAttorneyStatus.Status == shared.AttorneyStatusActive && lpa.Attorneys[*changeAttorneyStatus.Index].Status == shared.AttorneyStatusRemoved {
+			return []shared.FieldError{{Source: source, Detail: "A removed attorney cannot be made active"}}
+		}
+
+		lpa.Attorneys[*changeAttorneyStatus.Index].Status = changeAttorneyStatus.Status
+	}
+
+	return nil
+}
+
+func validateChangeAttorney(changes []shared.Change, lpa *shared.Lpa) (ChangeAttorney, []shared.FieldError) {
+	var data ChangeAttorney
+	key := -1
+
+	errors := parse.Changes(changes).
+		Prefix("/attorneys", func(p *parse.Parser) []shared.FieldError {
+			return p.
+				Each(func(i int, p *parse.Parser) []shared.FieldError {
+					key++
+					data.ChangeAttorneyStatus = append(data.ChangeAttorneyStatus, ChangeAttorneyStatus{Index: &i, Status: lpa.Attorneys[i].Status})
+
+					return p.
+						Field("/status", &data.ChangeAttorneyStatus[key].Status, parse.Validate(func() []shared.FieldError {
+							return validate.IsValid("", data.ChangeAttorneyStatus[key].Status)
+						})).
+						Consumed()
+				}).
+				Consumed()
+		}).
+		Consumed()
+
+	return data, errors
+}

--- a/lambda/update/change_attorneys.go
+++ b/lambda/update/change_attorneys.go
@@ -49,9 +49,7 @@ func validateChangeAttorney(changes []shared.Change, lpa *shared.Lpa) (ChangeAtt
 					data.ChangeAttorneyStatus = append(data.ChangeAttorneyStatus, ChangeAttorneyStatus{Index: &i, Status: lpa.Attorneys[i].Status})
 
 					return p.
-						Field("/status", &data.ChangeAttorneyStatus[key].Status, parse.Validate(func() []shared.FieldError {
-							return validate.IsValid("", data.ChangeAttorneyStatus[key].Status)
-						})).
+						Field("/status", &data.ChangeAttorneyStatus[key].Status, parse.Validate(validate.Valid())).
 						Consumed()
 				}).
 				Consumed()

--- a/lambda/update/change_attorneys.go
+++ b/lambda/update/change_attorneys.go
@@ -19,9 +19,6 @@ type ChangeAttorneyStatus struct {
 func (a ChangeAttorney) Apply(lpa *shared.Lpa) []shared.FieldError {
 	for _, changeAttorneyStatus := range a.ChangeAttorneyStatus {
 		source := "/attorneys/" + strconv.Itoa(*changeAttorneyStatus.Index) + "/status"
-		if changeAttorneyStatus.Status == shared.AttorneyStatusRemoved && lpa.Attorneys[*changeAttorneyStatus.Index].Status == shared.AttorneyStatusInactive {
-			return []shared.FieldError{{Source: source, Detail: "An inactive attorney cannot be removed"}}
-		}
 
 		if changeAttorneyStatus.Status == shared.AttorneyStatusInactive && lpa.Attorneys[*changeAttorneyStatus.Index].Status == shared.AttorneyStatusActive {
 			return []shared.FieldError{{Source: source, Detail: "An active attorney cannot be made inactive"}}

--- a/lambda/update/change_attorneys_test.go
+++ b/lambda/update/change_attorneys_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestChangeAttorneysApply(t *testing.T) {
+	attorneyIndex := 1
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			Attorneys: []shared.Attorney{
+				{}, {},
+			},
+		},
+	}
+
+	changeAttorney := ChangeAttorney{
+		ChangeAttorneyStatus: []ChangeAttorneyStatus{
+			{
+				Index:  &attorneyIndex,
+				Status: shared.AttorneyStatusActive,
+			},
+		},
+	}
+
+	errors := changeAttorney.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
+}
+
+func TestChangeAttorneysIncorrectStatus(t *testing.T) {
+	attorneyIndex0 := 0
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			Attorneys: []shared.Attorney{
+				{Status: shared.AttorneyStatusActive}, {Status: shared.AttorneyStatusInactive},
+			},
+		},
+	}
+
+	changeAttorney := ChangeAttorney{
+		ChangeAttorneyStatus: []ChangeAttorneyStatus{
+			{
+				Index:  &attorneyIndex0,
+				Status: shared.AttorneyStatusInactive,
+			},
+		},
+	}
+
+	errors := changeAttorney.Apply(lpa)
+	assert.Equal(t, errors,
+		[]shared.FieldError{
+			{
+				Source: "/attorneys/0/status",
+				Detail: "An active attorney cannot be made inactive",
+			},
+		})
+}
+
+func TestValidateUpdateChangeAttorneys(t *testing.T) {
+	testcases := map[string]struct {
+		update shared.Update
+		lpa    *shared.Lpa
+		errors []shared.FieldError
+	}{
+		"valid - with previous values": {
+			update: shared.Update{
+				Type: "CHANGE_ATTORNEYS",
+				Changes: []shared.Change{
+					{
+						Key: "/attorneys/1/status",
+						New: json.RawMessage(`"removed"`),
+						Old: json.RawMessage(`"active"`),
+					},
+					{
+						Key: "/attorneys/2/status",
+						New: json.RawMessage(`"active"`),
+						Old: json.RawMessage(`"inactive"`),
+					},
+				},
+			},
+			lpa: &shared.Lpa{LpaInit: shared.LpaInit{Attorneys: []shared.Attorney{
+				{Status: shared.AttorneyStatusActive}, {Status: shared.AttorneyStatusActive}, {Status: shared.AttorneyStatusInactive},
+			}}},
+		},
+		"invalid status": {
+			update: shared.Update{
+				Type: "CHANGE_ATTORNEYS",
+				Changes: []shared.Change{
+					{
+						Key: "/attorneys/0/status",
+						New: json.RawMessage(`"in-progress"`),
+						Old: json.RawMessage(`"active"`),
+					},
+				},
+			},
+			lpa: &shared.Lpa{LpaInit: shared.LpaInit{Attorneys: []shared.Attorney{
+				{Status: shared.AttorneyStatusActive}, {Status: shared.AttorneyStatusInactive},
+			}}},
+			errors: []shared.FieldError{
+				{Source: "/changes/0/new", Detail: "invalid value"},
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			_, errors := validateUpdate(tc.update, tc.lpa)
+			assert.ElementsMatch(t, tc.errors, errors)
+		})
+	}
+}

--- a/lambda/update/parse/changes.go
+++ b/lambda/update/parse/changes.go
@@ -170,6 +170,13 @@ func oldEqualsExisting(old any, existing any) bool {
 
 		return shared.LpaStatus(old.(string)) == *v
 
+	case *shared.AttorneyStatus:
+		if old == nil {
+			return *v == ""
+		}
+
+		return shared.AttorneyStatus(old.(string)) == *v
+
 	case *shared.Date:
 		if old == nil {
 			return v.IsZero()

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -36,6 +36,8 @@ func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.
 		return validateTrustCorporationOptOut(update)
 	case "CORRECTION":
 		return validateCorrection(update.Changes, lpa)
+	case "CHANGE_ATTORNEYS":
+		return validateChangeAttorney(update.Changes, lpa)
 	default:
 		return nil, []shared.FieldError{{Source: "/type", Detail: "invalid value"}}
 	}


### PR DESCRIPTION
# Purpose

This PR covers [VEGA-2822](https://opgtransform.atlassian.net/browse/VEGA-2822)

## Approach

The changes add a new validation / application file for changing the attorney status manually. The implementation only allows the status changes to multiple attorneys at the same time. This will cover both the removal of an attorney as well as enabling a replacement attorney.

[VEGA-2822]: https://opgtransform.atlassian.net/browse/VEGA-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ