### PR TITLE
Turn off SonarCloud duplicate code detection

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,1 +1,2 @@
 sonar.exclusions=**/mock_*_test.go
+sonar.cpd.exclusions=**/*


### PR DESCRIPTION
It's very rarely helpful and constantly throws false positives
