### PR TITLE
Do not require signatures from inactive attorneys

### DIFF
--- a/lambda/update/statutory_waiting_period.go
+++ b/lambda/update/statutory_waiting_period.go
@@ -20,7 +20,7 @@ func (r StatutoryWaitingPeriod) Apply(lpa *shared.Lpa) []shared.FieldError {
 	}
 
 	for _, a := range lpa.Attorneys {
-		if a.SignedAt == nil || a.SignedAt.IsZero() {
+		if a.Status != shared.AttorneyStatusInactive && (a.SignedAt == nil || a.SignedAt.IsZero()) {
 			return []shared.FieldError{{Source: "/type", Detail: "lpa must be signed by attorneys"}}
 		}
 	}

--- a/lambda/update/statutory_waiting_period_test.go
+++ b/lambda/update/statutory_waiting_period_test.go
@@ -82,6 +82,20 @@ func TestStatutoryWaitingPeriodApplyWhenUnsigned(t *testing.T) {
 			},
 			errors: []shared.FieldError{{Source: "/type", Detail: "lpa must be signed by attorneys"}},
 		},
+		"attorney, but not inactives": {
+			lpa: &shared.Lpa{
+				Status: shared.LpaStatusInProgress,
+				LpaInit: shared.LpaInit{
+					SignedAt:            now,
+					CertificateProvider: shared.CertificateProvider{SignedAt: &now},
+					Attorneys:           []shared.Attorney{{SignedAt: &now}, {Status: shared.AttorneyStatusInactive}},
+					TrustCorporations: []shared.TrustCorporation{{
+						Signatories: []shared.Signatory{{SignedAt: now}},
+					}},
+				},
+			},
+			errors: nil,
+		},
 		"trust corporation": {
 			lpa: &shared.Lpa{
 				Status: shared.LpaStatusInProgress,


### PR DESCRIPTION
# Purpose

Only active and replacement attorneys need to have signed the LPA for it to be registered.

Fixes VEGA-2896 #minor

## Approach

Tweaked logic, added test
