### PR TITLE
Make `contactLanguagePreference` and `mobile` optional when signing an LPA

### DIFF
--- a/lambda/update/attorney_sign.go
+++ b/lambda/update/attorney_sign.go
@@ -53,9 +53,9 @@ func validateAttorneySign(changes []shared.Change, lpa *shared.Lpa) (AttorneySig
 					}
 
 					return p.
-						Field("/mobile", &data.Mobile).
+						Field("/mobile", &data.Mobile, parse.Optional()).
 						Field("/signedAt", &data.SignedAt, parse.Validate(validate.NotEmpty())).
-						Field("/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid())).
+						Field("/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid()), parse.Optional()).
 						Field("/channel", &data.Channel, parse.Validate(validate.Valid()), parse.Optional()).
 						Field("/email", &data.Email, parse.Optional()).
 						Consumed()

--- a/lambda/update/attorney_sign_test.go
+++ b/lambda/update/attorney_sign_test.go
@@ -58,18 +58,8 @@ func TestValidateUpdateAttorneySign(t *testing.T) {
 				Type: "ATTORNEY_SIGN",
 				Changes: []shared.Change{
 					{
-						Key: "/attorneys/0/mobile",
-						New: json.RawMessage(`"07777"`),
-						Old: jsonNull,
-					},
-					{
 						Key: "/attorneys/0/signedAt",
 						New: json.RawMessage(`"` + time.Now().Format(time.RFC3339Nano) + `"`),
-						Old: jsonNull,
-					},
-					{
-						Key: "/attorneys/0/contactLanguagePreference",
-						New: json.RawMessage(`"cy"`),
 						Old: jsonNull,
 					},
 				},

--- a/lambda/update/certificate_provider_sign.go
+++ b/lambda/update/certificate_provider_sign.go
@@ -54,7 +54,7 @@ func validateCertificateProviderSign(changes []shared.Change, lpa *shared.Lpa) (
 				Consumed()
 		}, parse.Optional()).
 		Field("/certificateProvider/signedAt", &data.SignedAt, parse.Validate(validate.NotEmpty())).
-		Field("/certificateProvider/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid())).
+		Field("/certificateProvider/contactLanguagePreference", &data.ContactLanguagePreference, parse.Validate(validate.Valid()), parse.Optional()).
 		Field("/certificateProvider/email", &data.Email, parse.Validate(validate.NotEmpty()), parse.Optional()).
 		Field("/certificateProvider/channel", &data.Channel, parse.Validate(validate.Valid()), parse.Optional()).
 		Consumed()

--- a/lambda/update/certificate_provider_sign_test.go
+++ b/lambda/update/certificate_provider_sign_test.go
@@ -201,7 +201,6 @@ func TestValidateUpdateCertificateProviderSign(t *testing.T) {
 			update: shared.Update{Type: "CERTIFICATE_PROVIDER_SIGN"},
 			errors: []shared.FieldError{
 				{Source: "/changes", Detail: "missing /certificateProvider/signedAt"},
-				{Source: "/changes", Detail: "missing /certificateProvider/contactLanguagePreference"},
 			},
 		},
 		"bad address": {
@@ -227,7 +226,6 @@ func TestValidateUpdateCertificateProviderSign(t *testing.T) {
 				{Source: "/changes", Detail: "missing /certificateProvider/address/town"},
 				{Source: "/changes/1/new", Detail: "must be a valid ISO-3166-1 country code"},
 				{Source: "/changes", Detail: "missing /certificateProvider/signedAt"},
-				{Source: "/changes", Detail: "missing /certificateProvider/contactLanguagePreference"},
 			},
 		},
 		"extra fields": {

--- a/lambda/update/main_test.go
+++ b/lambda/update/main_test.go
@@ -201,7 +201,7 @@ func TestHandleEventWhenUpdateInvalid(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
-	assert.JSONEq(t, `{"code":"INVALID_REQUEST","detail":"Invalid request","errors":[{"source":"/changes","detail":"missing /certificateProvider/signedAt"},{"source":"/changes","detail":"missing /certificateProvider/contactLanguagePreference"}]}`, resp.Body)
+	assert.JSONEq(t, `{"code":"INVALID_REQUEST","detail":"Invalid request","errors":[{"source":"/changes","detail":"missing /certificateProvider/signedAt"}]}`, resp.Body)
 }
 
 func TestHandleEventWhenLpaNotFound(t *testing.T) {

--- a/mock-apigw/main.go
+++ b/mock-apigw/main.go
@@ -106,6 +106,10 @@ func delegateHandler(w http.ResponseWriter, r *http.Request) {
 	var respBody events.APIGatewayProxyResponse
 	_ = json.Unmarshal(encodedRespBody, &respBody)
 
+	if respBody.StatusCode == 0 {
+		log.Print(string(encodedRespBody))
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(respBody.StatusCode)
 	_, err = w.Write([]byte(respBody.Body))


### PR DESCRIPTION
# Purpose

Make `contactLanguagePreference` and `mobile` optional when signing an LPA

Fixes VEGA-2902 #minor
