### PR TITLE
Add attorney/CP sign forms to fixtures

### DIFF
--- a/fixtures/Dockerfile
+++ b/fixtures/Dockerfile
@@ -18,6 +18,9 @@ COPY fixtures/lib lib
 COPY --from=builder /app/node_modules/govuk-frontend/dist/govuk/assets static
 COPY --from=builder /app/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.css static
 COPY --from=builder /app/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js static
+COPY --from=builder /app/node_modules/@ministryofjustice/frontend/moj/assets static
+COPY --from=builder /app/node_modules/@ministryofjustice/frontend/moj/moj-frontend.min.css static
+COPY --from=builder /app/node_modules/@ministryofjustice/frontend/moj/moj-frontend.min.js static
 COPY fixtures/static static
 COPY fixtures/templates templates
 COPY docs/schemas static/schemas

--- a/fixtures/app.py
+++ b/fixtures/app.py
@@ -25,9 +25,14 @@ formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(messag
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 
+DATE_FORMAT_DATEPICKER = "%d/%m/%Y"
+DATE_FORMAT_LPA_STORE = "%Y-%m-%dT12:34:00Z"
+
 
 def prepare_date(date_string: str) -> str:
-    return datetime.strptime(date_string, "%d/%m/%Y").strftime("%Y-%m-%dT12:34:00Z")
+    return datetime.strptime(date_string, DATE_FORMAT_DATEPICKER).strftime(
+        DATE_FORMAT_LPA_STORE
+    )
 
 
 @app.route("/health-check", methods=["GET"])
@@ -118,7 +123,9 @@ def post_form_donor():
 @app.route("/form/certificate-provider", methods=["GET", "POST"])
 def get_form_cp():
     uid = request.form.get("uid", "")
-    signed_at = request.form.get("signedAt", datetime.now().strftime("%d/%m/%Y"))
+    signed_at = request.form.get(
+        "signedAt", datetime.now().strftime(DATE_FORMAT_DATEPICKER)
+    )
 
     if request.method == "POST":
         resp = certificate_provider_sign(uid, prepare_date(signed_at))
@@ -144,7 +151,9 @@ def get_form_cp():
 def get_form_attorney():
     uid = request.form.get("uid", "")
     attorney_uuid = request.form.get("attorneyUuid", "")
-    signed_at = request.form.get("signedAt", datetime.now().strftime("%d/%m/%Y"))
+    signed_at = request.form.get(
+        "signedAt", datetime.now().strftime(DATE_FORMAT_DATEPICKER)
+    )
 
     if request.method == "POST":
         try:

--- a/fixtures/app.py
+++ b/fixtures/app.py
@@ -1,8 +1,10 @@
 import requests, os, logging, sys, json, uuid
 from lib.aws_auth import AwsAuth
 from lib.jwt import generate_jwt
+from lib.api import attorney_sign, certificate_provider_sign
 from urllib.parse import quote
 
+from datetime import datetime
 from flask import Flask, render_template, request, jsonify
 from flask_wtf import CSRFProtect
 
@@ -22,6 +24,10 @@ handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
+
+
+def prepare_date(date_string: str) -> str:
+    return datetime.strptime(date_string, "%d/%m/%Y").strftime("%Y-%m-%dT12:34:00Z")
 
 
 @app.route("/health-check", methods=["GET"])
@@ -58,7 +64,7 @@ def health_check_dependencies():
 
 
 @app.route("/", methods=["GET"])
-def get_index():
+def get_form_donor():
     base_url = os.environ["BASE_URL"]
 
     return render_template(
@@ -71,7 +77,7 @@ def get_index():
 
 
 @app.route("/", methods=["POST"])
-def post_index():
+def post_form_donor():
     aws_auth = AwsAuth()
 
     uid = request.form.get("uid", "")
@@ -106,6 +112,62 @@ def post_index():
         },
         success=resp.status_code < 400,
         error=json.loads(resp.text),
+    )
+
+
+@app.route("/form/certificate-provider", methods=["GET", "POST"])
+def get_form_cp():
+    uid = request.form.get("uid", "")
+    signed_at = request.form.get("signedAt", datetime.now().strftime("%d/%m/%Y"))
+
+    if request.method == "POST":
+        resp = certificate_provider_sign(uid, prepare_date(signed_at))
+        success = resp.status_code < 400
+        error = json.loads(resp.text)
+    else:
+        success = None
+        error = None
+
+    return render_template(
+        "form_signature.html",
+        **{
+            "actor_type": "Certificate provider",
+            "uid": uid,
+            "signed_at": signed_at,
+        },
+        success=success,
+        error=error,
+    )
+
+
+@app.route("/form/attorney", methods=["GET", "POST"])
+def get_form_attorney():
+    uid = request.form.get("uid", "")
+    attorney_uuid = request.form.get("attorneyUuid", "")
+    signed_at = request.form.get("signedAt", datetime.now().strftime("%d/%m/%Y"))
+
+    if request.method == "POST":
+        try:
+            resp = attorney_sign(uid, attorney_uuid, prepare_date(signed_at))
+            success = resp.status_code < 400
+            error = json.loads(resp.text)
+        except Exception as e:
+            success = False
+            error = {"detail": str(e)}
+    else:
+        success = None
+        error = None
+
+    return render_template(
+        "form_signature.html",
+        **{
+            "actor_type": "Attorney",
+            "uid": uid,
+            "attorney_uuid": attorney_uuid,
+            "signed_at": signed_at,
+        },
+        success=success,
+        error=error,
     )
 
 

--- a/fixtures/lib/api.py
+++ b/fixtures/lib/api.py
@@ -1,0 +1,96 @@
+import json, requests, os
+from lib.aws_auth import AwsAuth
+from lib.jwt import generate_jwt
+from urllib.parse import quote
+
+
+def __get_lpa(uid):
+    aws_auth = AwsAuth()
+
+    base_url = os.environ["BASE_URL"]
+
+    url = base_url + "/lpas/" + quote(uid)
+
+    if aws_auth.is_authed:
+        headers = aws_auth.get_headers(method="GET", url=url)
+    else:
+        headers = {}
+
+    token = generate_jwt(os.environ["JWT_SECRET_KEY"])
+
+    response = requests.get(
+        url,
+        headers={
+            **headers,
+            "Content-Type": "application/json",
+            "X-Jwt-Authorization": "Bearer " + token,
+        },
+    )
+
+    return json.loads(response.text)
+
+
+def __send_correction(uid, type, *changes) -> requests.Response:
+    aws_auth = AwsAuth()
+
+    base_url = os.environ["BASE_URL"]
+
+    url = base_url + "/lpas/" + quote(uid) + "/updates"
+
+    body = json.dumps(
+        {
+            "type": type,
+            "changes": changes,
+        }
+    )
+
+    if aws_auth.is_authed:
+        headers = aws_auth.get_headers(method="POST", url=url, data=body)
+    else:
+        headers = {}
+
+    token = generate_jwt(os.environ["JWT_SECRET_KEY"])
+
+    return requests.post(
+        url,
+        body,
+        headers={
+            **headers,
+            "Content-Type": "application/json",
+            "X-Jwt-Authorization": "Bearer " + token,
+        },
+    )
+
+
+def attorney_sign(uid, attorney_uuid, signed_at) -> requests.Response:
+    lpa = __get_lpa(uid)
+
+    attorney_index = None
+    for index, attorney in enumerate(lpa["attorneys"]):
+        if attorney["uid"] == attorney_uuid:
+            attorney_index = index
+
+    if attorney_index == None:
+        raise Exception("Could not find attorney with UID {}".format(attorney_uuid))
+
+    return __send_correction(
+        uid,
+        "ATTORNEY_SIGN",
+        {
+            "key": "/attorneys/{}/signedAt".format(attorney_index),
+            "old": None,
+            "new": signed_at,
+        },
+    )
+
+
+def certificate_provider_sign(uid, signed_at) -> requests.Response:
+    return __send_correction(
+        uid,
+        "CERTIFICATE_PROVIDER_SIGN",
+        {
+            "key": "/certificateProvider/signedAt",
+            "old": None,
+            "new": signed_at,
+        },
+    )

--- a/fixtures/package-lock.json
+++ b/fixtures/package-lock.json
@@ -9,7 +9,22 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@ministryofjustice/frontend": "^4.0.1",
         "govuk-frontend": "^5.2.0"
+      }
+    },
+    "node_modules/@ministryofjustice/frontend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-4.0.1.tgz",
+      "integrity": "sha512-LljgnzLtTIw9z8mw/pK1xLIyR3TtHrFa9Z/i7X+6odzN5MlQ0dYLDXunoAhniXeOlXz5sNbdsmGuf/iNxv0keA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.2.0"
+      },
+      "peerDependencies": {
+        "govuk-frontend": "5.x",
+        "jquery": "3.x",
+        "moment": "2.x"
       }
     },
     "node_modules/govuk-frontend": {
@@ -19,6 +34,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"
+      }
+    },
+    "node_modules/jquery": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     }
   }

--- a/fixtures/package.json
+++ b/fixtures/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@ministryofjustice/frontend": "^4.0.1",
     "govuk-frontend": "^5.2.0"
   }
 }

--- a/fixtures/templates/form_signature.html
+++ b/fixtures/templates/form_signature.html
@@ -1,0 +1,54 @@
+{% extends "layout.html" %}
+
+{% block title %}{{ actor_type }} signature{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">{{ actor_type }} signature</h1>
+
+{% if success == True %}
+<div class="govuk-notification-banner govuk-notification-banner--success" role="alert"
+  aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Success
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-body">{{ actor_type }} signature was submitted</p>
+  </div>
+</div>
+{% elif success == False %}
+{% include "partials/error_summary.html" %}
+{% endif %}
+
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="f-uid">UID</label>
+    <input class="govuk-input govuk-input--width-20" id="f-uid" name="uid" type="text" value="{{ uid }}" required />
+  </div>
+
+  {% if actor_type == "Attorney" %}
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="f-attorney-uuid">Attorney UUID</label>
+    <input class="govuk-input govuk-input--width-20" id="f-attorney-uuid" name="attorneyUuid" type="text"
+      value="{{ attorney_uuid }}" required />
+  </div>
+  {% endif %}
+
+  <div class="moj-datepicker" data-module="moj-date-picker">
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="f-signed-at">
+        Signed at
+      </label>
+      <input class="govuk-input moj-js-datepicker-input" id="f-signed-at" name="signedAt" type="text"
+        value="{{ signed_at }}" required />
+    </div>
+  </div>
+
+  <button type="submit" class="govuk-button" data-module="govuk-button">
+    Send
+  </button>
+</form>
+{% endblock %}

--- a/fixtures/templates/index.html
+++ b/fixtures/templates/index.html
@@ -1,118 +1,49 @@
-<!DOCTYPE html>
+{% extends "layout.html" %}
 
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="stylesheet" href="assets/govuk-frontend.min.css" />
-    <title>Add a new LPA</title>
-    <style>
-      .govuk-form-group .govuk-form-group:last-of-type {
-        margin-bottom: 30px;
-      }
-    </style>
-  </head>
-  <body class="govuk-template__body">
-    <script>
-      document.body.className +=
-        " js-enabled" +
-        ("noModule" in HTMLScriptElement.prototype
-          ? " govuk-frontend-supported"
-          : "");
-    </script>
+{% block title %}Add a new LPA{% endblock %}
 
-    <div class="govuk-width-container">
-      <main class="govuk-main-wrapper" id="main-content" role="main">
-        <h1 class="govuk-heading-xl">Add a new LPA</h1>
+{% block content %}
+<h1 class="govuk-heading-xl">Add a new LPA</h1>
 
-        {% if success is defined %} {% if success == True %}
-        <div
-          class="govuk-notification-banner govuk-notification-banner--success"
-          role="alert"
-          aria-labelledby="govuk-notification-banner-title"
-          data-module="govuk-notification-banner"
-        >
-          <div class="govuk-notification-banner__header">
-            <h2
-              class="govuk-notification-banner__title"
-              id="govuk-notification-banner-title"
-            >
-              Success
-            </h2>
-          </div>
-          <div class="govuk-notification-banner__content">
-            <p class="govuk-body">LPA {{ uid }} was created</p>
-          </div>
-        </div>
-        {% else %}
-        <div class="govuk-error-summary" data-module="govuk-error-summary">
-          <div role="alert">
-            <h2 class="govuk-error-summary__title">{{ error.detail }}</h2>
-            <div class="govuk-error-summary__body">
-              <ul class="govuk-list govuk-error-summary__list">
-                {% for err in error.errors %}
-                <li>
-                  <a href="#f-{{err.source}}"
-                    >{{ err.source }}: {{ err.detail }}</a
-                  >
-                </li>
-                {% endfor %}
-              </ul>
-            </div>
-          </div>
-        </div>
-        {% endif %} {% endif %}
+{% if success is defined %}
+{% if success == True %}
+<div class="govuk-notification-banner govuk-notification-banner--success" role="alert"
+  aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Success
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-body">LPA {{ uid }} was created</p>
+  </div>
+</div>
+{% else %}
+{% include "partials/error_summary.html" %}
+{% endif %}
+{% endif %}
 
-        <form method="post">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+<form method="post">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
 
-          <div class="govuk-form-group">
-            <label class="govuk-label govuk-label--m" for="f-uid">UID</label>
-            <input
-              class="govuk-input govuk-input--width-20"
-              id="f-uid"
-              name="uid"
-              type="text"
-              value="{{ uid }}"
-              required
-              data-module="uid-generator"
-            />
-          </div>
+  <div class="govuk-form-group">
+    <label class="govuk-label govuk-label--m" for="f-uid">UID</label>
+    <input class="govuk-input govuk-input--width-20" id="f-uid" name="uid" type="text" value="{{ uid }}" required
+      data-module="uid-generator" />
+  </div>
 
-          <div class="govuk-form-group">
-            <label class="govuk-label govuk-label--m" for="f-json-data">
-              LPA content
-            </label>
-            <textarea
-              class="govuk-textarea"
-              name="json-data"
-              id="f-json-data"
-              required
-              rows="10"
-              data-module="json-schema-editor"
-              data-module-json-schema-editor-url="assets/schemas/2024-10/donor-details.json"
-            >
-              {{- json_data -}}
-            </textarea>
-          </div>
+  <div class="govuk-form-group">
+    <label class="govuk-label govuk-label--m" for="f-json-data">
+      LPA content
+    </label>
+    <textarea class="govuk-textarea" name="json-data" id="f-json-data" required rows="10"
+      data-module="json-schema-editor" data-module-json-schema-editor-url="assets/schemas/2024-10/donor-details.json">
+      {{- json_data -}}
+    </textarea>
+  </div>
 
-          <button type="submit" class="govuk-button" data-module="govuk-button">
-            Send
-          </button>
-        </form>
-      </main>
-    </div>
-
-    <script
-      src="https://cdn.jsdelivr.net/npm/json-schema-library@9.3.4/dist/jsonSchemaLibrary.min.js"
-      integrity="sha384-RePbUf/gtYzyS1nEErY0oNbL9zMtjU3TXf4Dj4FBEmhclyRv8pPvibkBEMUpd/c3"
-      crossorigin="anonymous"
-    ></script>
-    <script type="module">
-      import { initAll as govukInitAll } from "./assets/govuk-frontend.min.js";
-      import { initAll as appInitAll } from "./assets/js/main.mjs";
-
-      govukInitAll();
-      appInitAll();
-    </script>
-  </body>
-</html>
+  <button type="submit" class="govuk-button" data-module="govuk-button">
+    Send
+  </button>
+</form>
+{% endblock %}

--- a/fixtures/templates/layout.html
+++ b/fixtures/templates/layout.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="stylesheet" href="/assets/govuk-frontend.min.css" />
+  <link rel="stylesheet" href="/assets/moj-frontend.min.css" />
+  <title>{% block title %}{% endblock %}</title>
+  <style>
+    .govuk-form-group .govuk-form-group:last-of-type {
+      margin-bottom: 30px;
+    }
+  </style>
+</head>
+
+<body class="govuk-template__body">
+  <script>
+    document.body.className +=
+      " js-enabled" +
+      ("noModule" in HTMLScriptElement.prototype
+        ? " govuk-frontend-supported"
+        : "");
+  </script>
+
+  <div class="govuk-service-navigation" data-module="govuk-service-navigation">
+    <div class="govuk-width-container">
+      <div class="govuk-service-navigation__container">
+        <nav aria-label="Menu" class="govuk-service-navigation__wrapper">
+          <button type="button" class="govuk-service-navigation__toggle govuk-js-service-navigation-toggle"
+            aria-controls="navigation" hidden>
+            Menu
+          </button>
+          <ul class="govuk-service-navigation__list" id="navigation">
+
+            {% for route in (('get_form_donor', 'Donor'), ('get_form_cp', 'Certificate provider'),
+            ('get_form_attorney', 'Attorney')) %}
+            {%- if request.path == url_for(route[0]) %}
+            <li class="govuk-service-navigation__item govuk-service-navigation__item--active">
+              <a class="govuk-service-navigation__link" href="{{ url_for(route[0]) }}" aria-current="true">
+                <strong class="govuk-service-navigation__active-fallback">
+                  {{route[1]}}
+                </strong>
+              </a>
+            </li>
+            {% else %}
+            <li class="govuk-service-navigation__item">
+              <a class="govuk-service-navigation__link" href="{{ url_for(route[0]) }}">
+                {{route[1]}}
+              </a>
+            </li>
+            {% endif %}
+            {% endfor %}
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+      {% block content %}{% endblock %}
+    </main>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/json-schema-library@9.3.4/dist/jsonSchemaLibrary.min.js"
+    integrity="sha384-RePbUf/gtYzyS1nEErY0oNbL9zMtjU3TXf4Dj4FBEmhclyRv8pPvibkBEMUpd/c3"
+    crossorigin="anonymous"></script>
+  <script type="module">
+    import { initAll as govukInitAll } from "/assets/govuk-frontend.min.js";
+    import "/assets/moj-frontend.min.js";
+    import { initAll as appInitAll } from "/assets/js/main.mjs";
+
+    govukInitAll();
+    window.MOJFrontend.initAll();
+    appInitAll();
+  </script>
+</body>
+
+</html>

--- a/fixtures/templates/partials/error_summary.html
+++ b/fixtures/templates/partials/error_summary.html
@@ -1,0 +1,14 @@
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">{{ error.detail }}</h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        {% for err in error.errors %}
+        <li>
+          <a href="#f-{{err.source}}">{{ err.source }}: {{ err.detail }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
# Purpose

Add new endpoints where users can emulate an attorney of CP signing a paper form.

This will allow basic end-to-end testing of paper participants, letting Sirius test later stages of the process and providing more testing options.

Fixes VEGA-2807 #patch

## Approach

Added new endpoint handlers and templates.

I tidied up the existing HTML to add a reusable layout, and added an `api` library file to help with some of the repetitive bits.

I added `@ministryofjustice/frontend` for the date picker.

## Learning

N/A
