### PR TITLE
VEGA-2917 add sever restrictions and conditions to store

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -329,6 +329,7 @@ func TestUpdateToStatutoryWaitingPeriod(t *testing.T) {
 		{name: "DonorConfirmIdentity", path: "docs/donor-confirm-identity.json"},
 		{name: "CertificateProviderConfirmIdentity", path: "docs/certificate-provider-confirm-identity.json"},
 		{name: "StatutoryWaitingPeriod", path: "docs/statutory-waiting-period.json"},
+		{name: "SeverRestrictionsAndConditions", path: "docs/sever-restrictions-and-conditions.json"},
 	}
 
 	lpaUID := doCreateExample(t, examplePath)

--- a/api_test.go
+++ b/api_test.go
@@ -179,6 +179,7 @@ func TestCreateWithImages(t *testing.T) {
 			json.Unmarshal(getJSON["restrictionsAndConditionsImages"], &restrictionsAndConditionsImages)
 
 			getJSON["channel"] = json.RawMessage(`"online"`)
+			getJSON["restrictionsAndConditions"] = json.RawMessage(`"I do not want to be put into a care home unless x"`)
 			delete(getJSON, "status")
 			delete(getJSON, "uid")
 			delete(getJSON, "updatedAt")
@@ -337,6 +338,13 @@ func TestUpdateToStatutoryWaitingPeriod(t *testing.T) {
 	for _, step := range steps {
 		t.Run(step.name, func(t *testing.T) {
 			data, _ := os.ReadFile(step.path)
+
+			var requestData map[string]interface{}
+			if err := json.Unmarshal(data, &requestData); err != nil {
+				t.Fatalf("Failed to unmarshal JSON: %v", err)
+			}
+
+			// Log the type of 'new'
 
 			req, _ := http.NewRequest(http.MethodPost,
 				fmt.Sprintf("%s/lpas/%s/updates", baseURL, lpaUID),

--- a/docs/example-lpa.json
+++ b/docs/example-lpa.json
@@ -63,5 +63,6 @@
   "signedAt": "2024-01-10T23:00:00Z",
   "witnessedByCertificateProviderAt": "2024-01-11T01:00:00Z",
   "certificateProviderNotRelatedConfirmedAt": "2024-01-11T22:00:00Z",
-  "howAttorneysMakeDecisions": "jointly"
+  "howAttorneysMakeDecisions": "jointly",
+  "restrictionsAndConditions": "I do not want to be put into a care home unless x"
 }

--- a/docs/sever-restrictions-and-conditions.json
+++ b/docs/sever-restrictions-and-conditions.json
@@ -1,0 +1,10 @@
+{
+    "type": "SEVER_RESTRICTIONS_AND_CONDITIONS",
+    "changes": [
+        {
+            "key": "/restrictionsAndConditions",
+            "new": "I do not want to be put into a care home",
+            "old": "I do not want to be put into a care home unless x"
+        }
+    ]
+}

--- a/lambda/update/sever_restrictions.go
+++ b/lambda/update/sever_restrictions.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
-	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
 	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
 )
 
@@ -22,7 +21,7 @@ func validateSeverRestrictions(changes []shared.Change, lpa *shared.Lpa) (SeverR
 	data.restrictionsAndConditions = lpa.RestrictionsAndConditions
 
 	errors := parse.Changes(changes).
-		Field("/restrictionsAndConditions", &data.restrictionsAndConditions, parse.Validate(validate.Valid())).
+		Field("/restrictionsAndConditions", &data.restrictionsAndConditions, parse.Optional()).
 		Consumed()
 
 	return data, errors

--- a/lambda/update/sever_restrictions.go
+++ b/lambda/update/sever_restrictions.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
+	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
+)
+
+type SeverRestrictions struct {
+	restrictionsAndConditions string
+}
+
+func (r SeverRestrictions) Apply(lpa *shared.Lpa) []shared.FieldError {
+	lpa.RestrictionsAndConditions = r.restrictionsAndConditions
+
+	return nil
+}
+
+func validateSeverRestrictions(changes []shared.Change, lpa *shared.Lpa) (SeverRestrictions, []shared.FieldError) {
+	var data SeverRestrictions
+
+	data.restrictionsAndConditions = lpa.RestrictionsAndConditions
+
+	errors := parse.Changes(changes).
+		Field("/restrictionsAndConditions", &data.restrictionsAndConditions, parse.Validate(validate.Valid())).
+		Consumed()
+
+	return data, errors
+}

--- a/lambda/update/sever_restrictions_test.go
+++ b/lambda/update/sever_restrictions_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSeverRestrictionsApply(t *testing.T) {
+
+	testcases := map[string]struct {
+		newRestriction string
+		oldRestriction string
+	}{
+		"change restrictions": {
+			newRestriction: "I do want",
+			oldRestriction: "I do not want to x",
+		},
+		"can blank restrictions": {
+			newRestriction: "",
+			oldRestriction: "I want to x",
+		},
+	}
+
+	for scenario, tc := range testcases {
+		lpa := &shared.Lpa{
+			LpaInit: shared.LpaInit{
+				RestrictionsAndConditions: tc.newRestriction,
+			},
+		}
+
+		s := SeverRestrictions{
+			restrictionsAndConditions: tc.oldRestriction,
+		}
+
+		t.Run(scenario, func(t *testing.T) {
+			errors := s.Apply(lpa)
+			assert.Empty(t, errors)
+			assert.Equal(t, s.restrictionsAndConditions, lpa.RestrictionsAndConditions)
+		})
+	}
+}
+
+func TestValidateSeverRestrictions(t *testing.T) {
+
+	update := shared.Update{
+		Type: "SEVER_RESTRICTIONS_AND_CONDITIONS",
+		Changes: []shared.Change{
+			{
+				Key: "/restrictionsAndConditions",
+				New: json.RawMessage(`"I want"`),
+				Old: json.RawMessage(`"I do not want"`),
+			},
+		},
+	}
+
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			RestrictionsAndConditions: "I do not want",
+		},
+	}
+
+	_, errors := validateUpdate(update, lpa)
+	assert.ElementsMatch(t, errors, errors)
+}

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -38,6 +38,8 @@ func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.
 		return validateCorrection(update.Changes, lpa)
 	case "CHANGE_ATTORNEYS":
 		return validateChangeAttorney(update.Changes, lpa)
+	case "SEVER_RESTRICTIONS_AND_CONDITIONS":
+		return validateSeverRestrictions(update.Changes, lpa)
 	default:
 		return nil, []shared.FieldError{{Source: "/type", Detail: "invalid value"}}
 	}


### PR DESCRIPTION
# Purpose

Ticket to add SEVER_RESTRICTIONS_AND_CONDITIONS update change type, to allow changes to restrictions and conditions. This can in rare circumstances occur after registration. 

Fixes (VEGA-2917)

## Approach

Follows previously established patterns. 

