### PR TITLE
Create an API destination for opg-metrics

### DIFF
--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -3,7 +3,7 @@ data "aws_default_tags" "current" {
 }
 
 data "aws_secretsmanager_secret" "opg_metrics_api_key" {
-  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.environment-name}"
+  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.account}"
   provider = aws.shared_eu_west_1
 }
 

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -3,7 +3,7 @@ data "aws_default_tags" "current" {
 }
 
 data "aws_secretsmanager_secret" "opg_metrics_api_key" {
-  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.account-name}"
+  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.environment-name}"
   provider = aws.shared_eu_west_1
 }
 

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -1,0 +1,45 @@
+data "aws_default_tags" "current" {
+  provider = aws.eu_west_1
+}
+
+data "aws_secretsmanager_secret" "opg_metrics_api_key" {
+  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.account-name}"
+  provider = aws.shared_eu_west_1
+}
+
+data "aws_secretsmanager_secret_version" "opg_metrics_api_key" {
+  secret_id     = data.aws_secretsmanager_secret.opg_metrics_api_key.id
+  version_stage = "AWSCURRENT"
+  provider      = aws.shared_eu_west_1
+}
+
+resource "aws_cloudwatch_event_connection" "opg_metrics" {
+  name               = "opg-metrics"
+  description        = "Account level - connection and auth for opg-metrics"
+  authorization_type = "API_KEY"
+
+  auth_parameters {
+    api_key {
+      key   = "x-api-key"
+      value = data.aws_secretsmanager_secret_version.opg_metrics_api_key.secret_string
+    }
+  }
+  provider = aws.eu_west_1
+}
+
+resource "aws_cloudwatch_event_api_destination" "opg_metrics_put" {
+  name                             = "opg-metrics-put"
+  description                      = "Account level - an endpoint to push metrics to"
+  invocation_endpoint              = "${local.account.opg_metrics_endpoint}/metrics"
+  http_method                      = "PUT"
+  invocation_rate_limit_per_second = 300
+  connection_arn                   = aws_cloudwatch_event_connection.opg_metrics.arn
+  provider                         = aws.eu_west_1
+}
+
+resource "aws_ssm_parameter" "opg_metrics_arn" {
+  name     = "opg-metrics-api-destination-arn"
+  type     = "String"
+  value    = aws_cloudwatch_event_api_destination.opg_metrics_put.arn
+  provider = aws.eu_west_1
+}

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -3,7 +3,7 @@ data "aws_default_tags" "current" {
 }
 
 data "aws_secretsmanager_secret" "opg_metrics_api_key" {
-  name     = "opg-metrics-api-key/mrlpa-${data.aws_default_tags.current.tags.account}"
+  name     = "opg-metrics-api-key/lpa-store-${data.aws_default_tags.current.tags.account}"
   provider = aws.shared_eu_west_1
 }
 

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -80,3 +80,31 @@ provider "aws" {
     tags = local.default_tags
   }
 }
+
+provider "aws" {
+  alias  = "shared_eu_west_1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.default_role}"
+    session_name = "terraform-session"
+  }
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+provider "aws" {
+  alias  = "shared_eu_west_2"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.default_role}"
+    session_name = "terraform-session"
+  }
+
+  default_tags {
+    tags = local.default_tags
+  }
+}

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -17,7 +17,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {
@@ -31,7 +31,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {
@@ -45,7 +45,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.account_id}:role/${var.default_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {
@@ -59,7 +59,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {
@@ -73,7 +73,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::311462405659:role/${var.management_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {
@@ -87,7 +87,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.default_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {
@@ -101,7 +101,7 @@ provider "aws" {
 
   assume_role {
     role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.default_role}"
-    session_name = "terraform-session"
+    session_name = "lpa-store-terraform-session"
   }
 
   default_tags {

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -15,7 +15,8 @@
         "arn:aws:iam::653761790766:role/event-received-*",
         "arn:aws:iam::288342028542:role/api-ecs-*",
         "arn:aws:iam::367815980639:role/*-api-task-role"
-      ]
+      ],
+      "opg_metrics_endpoint": "https://development.api.metrics.opg.service.justice.gov.uk"
     },
     "preproduction": {
       "account_id": "936779158973",
@@ -34,7 +35,8 @@
         "arn:aws:iam::492687888235:role/api-ecs-finance",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction",
         "arn:aws:iam::888228022356:role/preproduction-api-task-role"
-      ]
+      ],
+      "opg_metrics_endpoint": "https://development.api.metrics.opg.service.justice.gov.uk"
     },
     "production": {
       "account_id": "764856231715",
@@ -51,7 +53,8 @@
         "arn:aws:iam::313879017102:role/event-received-*",
         "arn:aws:iam::649098267436:role/api-ecs-production",
         "arn:aws:iam::690083044361:role/production-api-task-role"
-      ]
+      ],
+      "opg_metrics_endpoint": "https://development.api.metrics.opg.service.justice.gov.uk"
     }
   }
 }

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -2,6 +2,7 @@
   "accounts": {
     "development": {
       "account_id": "493907465011",
+      "shared_account_id": "679638075911",
       "account_name": "development",
       "is_production": false,
       "jwt_key_cross_account_access": [
@@ -18,6 +19,7 @@
     },
     "preproduction": {
       "account_id": "936779158973",
+      "shared_account_id": "679638075911",
       "account_name": "preproduction",
       "is_production": false,
       "jwt_key_cross_account_access": [
@@ -36,6 +38,7 @@
     },
     "production": {
       "account_id": "764856231715",
+      "shared_account_id": "679638075911",
       "account_name": "production",
       "is_production": true,
       "jwt_key_cross_account_access": [

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -7,6 +7,7 @@ variable "accounts" {
       shared_account_id                  = string
       jwt_key_cross_account_access       = list(string)
       jwt_key_cross_account_access_roles = list(string)
+      opg_metrics_endpoint               = string
     })
   )
 }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -4,6 +4,7 @@ variable "accounts" {
       account_id                         = string
       account_name                       = string
       is_production                      = bool
+      shared_account_id                  = string
       jwt_key_cross_account_access       = list(string)
       jwt_key_cross_account_access_roles = list(string)
     })


### PR DESCRIPTION
# Purpose

Add an Eventbridge API destination for opg-metrics

Fixes MLPAB-2905

## Approach

NOTE: OPG metrics only currently exists in the shared-dev account, and only in the eu-west-1 region. All environments will point to this endpoint until production environments and dual region deployment is sorted for opg-metrics.

- add shared account providers
- create api destination
