### PR TITLE
MLPAB-2991 - add scheduled job to update api key for opg metrics

### DIFF
--- a/.github/workflows/schedule-update-opg-metrics-credentials.yml
+++ b/.github/workflows/schedule-update-opg-metrics-credentials.yml
@@ -1,0 +1,75 @@
+name: "[Scheduled] Update OPG Metrics API key"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '10 2 * * *' # Every 2:10 a.m.
+
+permissions:
+  id-token: write
+  contents: write
+  security-events: write
+  pull-requests: write
+  actions: none
+  checks: none
+  deployments: none
+  issues: write
+  packages: none
+  repository-projects: none
+  statuses: none
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  update_opg_metrics_api_keys:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: development
+            oidc_role: ""
+          - environment: preproduction
+            oidc_role: ""
+          - environment: production
+            oidc_role: ""
+    runs-on: ubuntu-latest
+    env:
+      tf_dir: "./terraform/account"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: "0"
+      - uses: unfor19/install-aws-cli-action@e8b481e524a99f37fbd39fdc1dcb3341ab091367 # v1.0.7
+      - name: "Parse terraform version [directory: ${{ env.tf_dir }}]"
+        id: tf_version
+        uses: ministryofjustice/opg-github-actions/.github/actions/terraform-version@73bfe6f3ea05ffbc3dd278fe29c113ec1e7dcefc # v3.1.1
+        with:
+          terraform_directory: ${{ env.tf_dir }}
+      - name: "Terraform version [${{ steps.tf_version.outputs.version }}]"
+        run: echo "terraform version [${{ steps.tf_version.outputs.version }}]" >> $GITHUB_STEP_SUMMARY
+        working-directory: ${{ env.tf_dir }}
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_version: ${{ steps.tf_version.outputs.version }}
+          terraform_wrapper: false
+      - name: Configure AWS Credentials For Terraform
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-1
+          role-duration-seconds: 3600
+          role-session-name: OPGLpaStoreGithubAction
+      - name: Terraform Init
+        run: terraform init -input=false
+        working-directory: ${{ env.tf_dir }}
+      - name: Terraform Update API OPG Metrics API destination
+        env:
+          TF_WORKSPACE: ${{ matrix.environment }}
+        run: |
+          terraform apply -lock-timeout=300s  -input=false -auto-approve \
+            -target 'aws_cloudwatch_event_api_destination.opg_metrics_put' \
+            -target 'aws_cloudwatch_event_connection.opg_metrics_put'
+        working-directory: ${{ env.tf_dir }}

--- a/.github/workflows/schedule-update-opg-metrics-credentials.yml
+++ b/.github/workflows/schedule-update-opg-metrics-credentials.yml
@@ -71,5 +71,5 @@ jobs:
         run: |
           terraform apply -lock-timeout=300s  -input=false -auto-approve \
             -target 'aws_cloudwatch_event_api_destination.opg_metrics_put' \
-            -target 'aws_cloudwatch_event_connection.opg_metrics_put'
+            -target 'aws_cloudwatch_event_connection.opg_metrics'
         working-directory: ${{ env.tf_dir }}


### PR DESCRIPTION
# Purpose

OPG Metrics rotates credentials on a daily basis. Lambda functions using OPG Metrics directly fetch API keys, but Event Bridge API destinations store a copy of the credentials. 

Fixes MLPAB-2991

## Approach

- Schedule a job after the API key rotation (2am) to update the stored credential

## Learning

- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
