### PR TITLE
Allow lambda role to GetObject from S3

### DIFF
--- a/terraform/environment/region/iam.tf
+++ b/terraform/environment/region/iam.tf
@@ -41,6 +41,7 @@ data "aws_iam_policy_document" "lambda_s3_policy" {
       "${var.lpa_store_static_bucket.arn}/*",
     ]
     actions = [
+      "s3:GetObject",
       "s3:PutObject"
     ]
   }


### PR DESCRIPTION
# Purpose

So that it can generate pre-signed URLs for images

Fixes VEGA-2984 #patch
