### PR TITLE
Don't lose order when grouping changes by key

### DIFF
--- a/lambda/update/parse/changes.go
+++ b/lambda/update/parse/changes.go
@@ -331,7 +331,7 @@ func (p *Parser) Each(fn func(int, *Parser) []shared.FieldError, required ...int
 //	})
 func (p *Parser) EachKey(fn func(string, *Parser) []shared.FieldError) *Parser {
 	fieldChanges := make(map[string][]changeWithPosition, len(p.changes))
-	keysOrdered := []string{}
+	keysOriginalOrder := []string{}
 
 	for _, change := range p.changes {
 		parts := strings.SplitN(change.Key, "/", 3)
@@ -340,8 +340,8 @@ func (p *Parser) EachKey(fn func(string, *Parser) []shared.FieldError) *Parser {
 			continue
 		}
 
-		if !slices.Contains(keysOrdered, parts[1]) {
-			keysOrdered = append(keysOrdered, parts[1])
+		if !slices.Contains(keysOriginalOrder, parts[1]) {
+			keysOriginalOrder = append(keysOriginalOrder, parts[1])
 		}
 
 		fieldChanges[parts[1]] = append(fieldChanges[parts[1]], changeWithPosition{
@@ -353,7 +353,7 @@ func (p *Parser) EachKey(fn func(string, *Parser) []shared.FieldError) *Parser {
 	// all changes are valid, so remove from current parser
 	p.changes = []changeWithPosition{}
 
-	for _, idx := range keysOrdered {
+	for _, idx := range keysOriginalOrder {
 		changes := fieldChanges[idx]
 		subParser := &Parser{root: p.root + "/" + idx, changes: changes}
 		fn(idx, subParser)

--- a/lambda/update/parse/changes.go
+++ b/lambda/update/parse/changes.go
@@ -331,12 +331,17 @@ func (p *Parser) Each(fn func(int, *Parser) []shared.FieldError, required ...int
 //	})
 func (p *Parser) EachKey(fn func(string, *Parser) []shared.FieldError) *Parser {
 	fieldChanges := make(map[string][]changeWithPosition, len(p.changes))
+	keysOrdered := []string{}
 
 	for _, change := range p.changes {
 		parts := strings.SplitN(change.Key, "/", 3)
 		if len(parts) != 3 || parts[1] == "" || parts[0] != "" {
 			p.errors = append(p.errors, shared.FieldError{Source: change.Source("/key"), Detail: "require index or actor UID"})
 			continue
+		}
+
+		if !slices.Contains(keysOrdered, parts[1]) {
+			keysOrdered = append(keysOrdered, parts[1])
 		}
 
 		fieldChanges[parts[1]] = append(fieldChanges[parts[1]], changeWithPosition{
@@ -348,7 +353,8 @@ func (p *Parser) EachKey(fn func(string, *Parser) []shared.FieldError) *Parser {
 	// all changes are valid, so remove from current parser
 	p.changes = []changeWithPosition{}
 
-	for idx, changes := range fieldChanges {
+	for _, idx := range keysOrdered {
+		changes := fieldChanges[idx]
 		subParser := &Parser{root: p.root + "/" + idx, changes: changes}
 		fn(idx, subParser)
 		p.errors = append(p.errors, subParser.errors...)


### PR DESCRIPTION
# Purpose

Iterating a hashmap makes some tests flakey.

Fixes CTC-205 #patch

## Approach

Iterating over a map causes the order to be unreliable, because hashmaps don't have order. This some error messages non-idempotent, which results in flakey tests.

Keep track of the order of the changes and process the groups based on which prefix had a value listed first.

## Learning

I didn't know you could do `-run {regex}` to only run particular tests with `go test`. That made recreating the bug and confirming the fix much easier.
