### PR TITLE
Ensure actors have UIDs on creation

### DIFF
--- a/lambda/create/main.go
+++ b/lambda/create/main.go
@@ -144,6 +144,20 @@ func (l *Lambda) HandleEvent(ctx context.Context, req events.APIGatewayProxyRequ
 		}
 	}
 
+	for i := range data.PeopleToNotify {
+		if data.PeopleToNotify[i].UID == "" {
+			data.PeopleToNotify[i].UID = uuid.NewString()
+		}
+	}
+
+	if data.IndependentWitness != nil && data.IndependentWitness.UID == "" {
+		data.IndependentWitness.UID = uuid.NewString()
+	}
+
+	if data.AuthorisedSignatory != nil && data.AuthorisedSignatory.UID == "" {
+		data.AuthorisedSignatory.UID = uuid.NewString()
+	}
+
 	// save
 	if err := l.store.Put(ctx, data); err != nil {
 		l.logger.Error("error saving LPA", slog.Any("err", err))

--- a/lambda/create/main.go
+++ b/lambda/create/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/google/uuid"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/ddb"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/event"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/objectstore"
@@ -119,6 +120,27 @@ func (l *Lambda) HandleEvent(ctx context.Context, req events.APIGatewayProxyRequ
 				l.logger.Error("error saving restrictions and conditions image", slog.Any("err", err))
 				return shared.ProblemInternalServerError.Respond()
 			}
+		}
+	}
+
+	// add UIDs to actors
+	if data.Donor.UID == "" {
+		data.Donor.UID = uuid.NewString()
+	}
+
+	if data.CertificateProvider.UID == "" {
+		data.CertificateProvider.UID = uuid.NewString()
+	}
+
+	for i := range data.Attorneys {
+		if data.Attorneys[i].UID == "" {
+			data.Attorneys[i].UID = uuid.NewString()
+		}
+	}
+
+	for i := range data.TrustCorporations {
+		if data.TrustCorporations[i].UID == "" {
+			data.TrustCorporations[i].UID = uuid.NewString()
 		}
 	}
 

--- a/lambda/create/main_test.go
+++ b/lambda/create/main_test.go
@@ -514,13 +514,19 @@ func TestLambdaHandleEventWhenSendLpaUpdatedErrors(t *testing.T) {
 	}, resp)
 }
 
-func TestLambdaHandleEventAddsAttorneyUids(t *testing.T) {
+func TestLambdaHandleEventAddsActorUids(t *testing.T) {
 	body, _ := json.Marshal(shared.LpaInit{
 		Channel: shared.ChannelPaper,
 		Donor: shared.Donor{
 			Person: shared.Person{
 				FirstNames: "donor-firstname",
 				LastName:   "donor-lastname",
+			},
+		},
+		CertificateProvider: shared.CertificateProvider{
+			Person: shared.Person{
+				FirstNames: "certificate-provider-firstname",
+				LastName:   "certificate-provider-lastname",
 			},
 		},
 		Attorneys: []shared.Attorney{
@@ -543,12 +549,12 @@ func TestLambdaHandleEventAddsAttorneyUids(t *testing.T) {
 			{},
 			{UID: "76fca433-639c-4119-8b3b-6f1e5d82de55"},
 		},
-		CertificateProvider: shared.CertificateProvider{
-			Person: shared.Person{
-				FirstNames: "certificate-provider-firstname",
-				LastName:   "certificate-provider-lastname",
-			},
+		PeopleToNotify: []shared.PersonToNotify{
+			{Person: shared.Person{UID: "752f2031-66c6-412d-b8b8-3f9d56bb6e86"}},
+			{},
 		},
+		IndependentWitness:  &shared.IndependentWitness{},
+		AuthorisedSignatory: &shared.AuthorisedSignatory{},
 	})
 
 	uuidRegex := regexp.MustCompile("^[0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12}$")
@@ -580,7 +586,11 @@ func TestLambdaHandleEventAddsAttorneyUids(t *testing.T) {
 				uuidRegex.MatchString(lpa.Attorneys[0].UID) &&
 				uuidRegex.MatchString(lpa.Attorneys[1].UID) &&
 				uuidRegex.MatchString(lpa.TrustCorporations[0].UID) &&
-				lpa.TrustCorporations[1].UID == "76fca433-639c-4119-8b3b-6f1e5d82de55"
+				lpa.TrustCorporations[1].UID == "76fca433-639c-4119-8b3b-6f1e5d82de55" &&
+				lpa.PeopleToNotify[0].UID == "752f2031-66c6-412d-b8b8-3f9d56bb6e86" &&
+				uuidRegex.MatchString(lpa.PeopleToNotify[1].UID) &&
+				uuidRegex.MatchString(lpa.IndependentWitness.UID) &&
+				uuidRegex.MatchString(lpa.AuthorisedSignatory.UID)
 		})).
 		Return(nil)
 

--- a/lambda/create/main_test.go
+++ b/lambda/create/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"regexp"
 	"testing"
 	"time"
 
@@ -495,6 +496,106 @@ func TestLambdaHandleEventWhenSendLpaUpdatedErrors(t *testing.T) {
 			ChangeType: "CREATE",
 		}).
 		Return(errExample)
+
+	lambda := &Lambda{
+		verifier:         verifier,
+		logger:           logger,
+		store:            store,
+		staticLpaStorage: staticLpaStorage,
+		eventClient:      eventClient,
+		now:              testNowFn,
+	}
+
+	resp, err := lambda.HandleEvent(ctx, req)
+	assert.Nil(t, err)
+	assert.Equal(t, events.APIGatewayProxyResponse{
+		StatusCode: 201,
+		Body:       "{}",
+	}, resp)
+}
+
+func TestLambdaHandleEventAddsAttorneyUids(t *testing.T) {
+	body, _ := json.Marshal(shared.LpaInit{
+		Channel: shared.ChannelPaper,
+		Donor: shared.Donor{
+			Person: shared.Person{
+				FirstNames: "donor-firstname",
+				LastName:   "donor-lastname",
+			},
+		},
+		Attorneys: []shared.Attorney{
+			{
+				Person: shared.Person{
+					FirstNames: "attorney-firstname",
+					LastName:   "attorney-lastname",
+				},
+				AppointmentType: shared.AppointmentTypeOriginal,
+			},
+			{
+				Person: shared.Person{
+					FirstNames: "attorney2-firstname",
+					LastName:   "attorney2-lastname",
+				},
+				AppointmentType: shared.AppointmentTypeReplacement,
+			},
+		},
+		TrustCorporations: []shared.TrustCorporation{
+			{},
+			{UID: "76fca433-639c-4119-8b3b-6f1e5d82de55"},
+		},
+		CertificateProvider: shared.CertificateProvider{
+			Person: shared.Person{
+				FirstNames: "certificate-provider-firstname",
+				LastName:   "certificate-provider-lastname",
+			},
+		},
+	})
+
+	uuidRegex := regexp.MustCompile("^[0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12}$")
+
+	req := events.APIGatewayProxyRequest{
+		PathParameters: map[string]string{"uid": "my-uid"},
+		Body:           string(body),
+	}
+
+	verifier := newMockVerifier(t)
+	verifier.EXPECT().
+		VerifyHeader(req).
+		Return(nil, nil)
+
+	logger := newMockLogger(t)
+	logger.EXPECT().
+		Debug("Successfully parsed JWT from event header")
+	logger.EXPECT().
+		Info("encountered validation errors in lpa", mock.Anything)
+
+	store := newMockStore(t)
+	store.EXPECT().
+		Get(ctx, "my-uid").
+		Return(shared.Lpa{}, nil)
+	store.EXPECT().
+		Put(ctx, mock.MatchedBy(func(lpa shared.Lpa) bool {
+			return uuidRegex.MatchString(lpa.Donor.UID) &&
+				uuidRegex.MatchString(lpa.CertificateProvider.UID) &&
+				uuidRegex.MatchString(lpa.Attorneys[0].UID) &&
+				uuidRegex.MatchString(lpa.Attorneys[1].UID) &&
+				uuidRegex.MatchString(lpa.TrustCorporations[0].UID) &&
+				lpa.TrustCorporations[1].UID == "76fca433-639c-4119-8b3b-6f1e5d82de55"
+		})).
+		Return(nil)
+
+	staticLpaStorage := newMockS3Client(t)
+	staticLpaStorage.EXPECT().
+		Put(ctx, "my-uid/donor-executed-lpa.json", mock.Anything).
+		Return(nil)
+
+	eventClient := newMockEventClient(t)
+	eventClient.EXPECT().
+		SendLpaUpdated(ctx, event.LpaUpdated{
+			Uid:        "my-uid",
+			ChangeType: "CREATE",
+		}).
+		Return(nil)
 
 	lambda := &Lambda{
 		verifier:         verifier,


### PR DESCRIPTION
If any actors have not been assigned a UID when the case is created, automatically add one.

This ensures they will have a consistent identity for all future events and interactions.

Fixes VEGA-2988 #minor
