### PR TITLE
Correct validation for howReplacementAttorneysMakeDecisions

### DIFF
--- a/lambda/create/validate.go
+++ b/lambda/create/validate.go
@@ -69,7 +69,7 @@ func Validate(lpa shared.LpaInit) []shared.FieldError {
 		validate.IfElse(lpa.HowReplacementAttorneysStepIn == shared.HowStepInAnotherWay,
 			validate.WithSource("/howReplacementAttorneysStepInDetails", lpa.HowReplacementAttorneysStepInDetails, validate.NotEmpty()),
 			validate.WithSource("/howReplacementAttorneysStepInDetails", lpa.HowReplacementAttorneysStepInDetails, validate.Empty())),
-		validate.IfElse(replacementAttorneyCount > 1 && (lpa.HowReplacementAttorneysStepIn == shared.HowStepInAllCanNoLongerAct || lpa.HowAttorneysMakeDecisions != shared.HowMakeDecisionsJointlyAndSeverally),
+		validate.IfElse(replacementAttorneyCount > 1 && (activeAttorneyCount == 1 || lpa.HowAttorneysMakeDecisions == shared.HowMakeDecisionsJointly || (lpa.HowAttorneysMakeDecisions == shared.HowMakeDecisionsJointlyAndSeverally && lpa.HowReplacementAttorneysStepIn == shared.HowStepInAllCanNoLongerAct)),
 			validate.WithSource("/howReplacementAttorneysMakeDecisions", lpa.HowReplacementAttorneysMakeDecisions, validate.Valid()),
 			validate.WithSource("/howReplacementAttorneysMakeDecisions", lpa.HowReplacementAttorneysMakeDecisions, validate.Unset())),
 		validate.IfElse(lpa.HowReplacementAttorneysMakeDecisions == shared.HowMakeDecisionsJointlyForSomeSeverallyForOthers,

--- a/lambda/create/validate_test.go
+++ b/lambda/create/validate_test.go
@@ -326,7 +326,7 @@ func TestValidateLpaInvalid(t *testing.T) {
 			lpa: func() shared.LpaInit {
 				lpa := makeLpaWithDonorAndActors()
 
-				lpa.Attorneys = []shared.Attorney{makeReplacementAttorney(), makeReplacementAttorney()}
+				lpa.Attorneys = []shared.Attorney{makeReplacementAttorney(), makeReplacementAttorney(), makeAttorney()}
 
 				return lpa
 			},
@@ -393,7 +393,7 @@ func TestValidateLpaInvalid(t *testing.T) {
 		"multiple replacement attorneys mixed without details": {
 			lpa: func() shared.LpaInit {
 				lpa := makeLpaWithDonorAndActors()
-				lpa.Attorneys = []shared.Attorney{makeReplacementAttorney(), makeReplacementAttorney()}
+				lpa.Attorneys = []shared.Attorney{makeReplacementAttorney(), makeReplacementAttorney(), makeAttorney()}
 				lpa.HowReplacementAttorneysMakeDecisions = shared.HowMakeDecisionsJointlyForSomeSeverallyForOthers
 
 				return lpa
@@ -406,7 +406,7 @@ func TestValidateLpaInvalid(t *testing.T) {
 			lpa: func() shared.LpaInit {
 				lpa := makeLpaWithDonorAndActors()
 
-				lpa.Attorneys = []shared.Attorney{makeReplacementAttorney(), makeReplacementAttorney()}
+				lpa.Attorneys = []shared.Attorney{makeReplacementAttorney(), makeReplacementAttorney(), makeAttorney()}
 				lpa.HowReplacementAttorneysMakeDecisions = shared.HowMakeDecisionsJointly
 				lpa.HowReplacementAttorneysMakeDecisionsDetails = "something"
 


### PR DESCRIPTION
Please double check my logic here with what is happening in opg-modernising-lpa. I spotted this by going through a scenario that didn't require answering "how should you replacement attorneys make decisions?", then on the contextual LPA saw "a default decisions has been selected" 😕.