### PR TITLE
Replace `anothrNick/github-tag-action` with `ministryofjustice/opg-github-actions/.github/actions/semver-tag`

### DIFF
--- a/.github/workflows/generate-tag.yml
+++ b/.github/workflows/generate-tag.yml
@@ -11,7 +11,7 @@ jobs:
   generate_tag:
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.bump_version.outputs.tag }}
+      tag: ${{ steps.semver_tag.outputs.created_tag }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -28,13 +28,8 @@ jobs:
             echo BRANCH_NAME=${branch} >> $GITHUB_ENV
           fi
       - name: Bump version
-        id: bump_version
-        uses: anothrNick/github-tag-action@e528bc2b9628971ce0e6f823f3052d1dcd9d512c # 1.73.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INITIAL_VERSION: 0.0.0
-          DEFAULT_BUMP: minor
-          PRERELEASE: true
-          PRERELEASE_SUFFIX: ${{ env.BRANCH_NAME }}
-          RELEASE_BRANCHES: main
-          TAG_PREFIX: v
+        id: semver_tag
+        uses: ministryofjustice/opg-github-actions/.github/actions/semver-tag@c9c5dfb290b8f614df0884928c521165ba83d630 # v3.1.4
+        with:
+          default_bump: minor
+          releases_enabled: false

--- a/terraform/account/terraform.tfvars.json
+++ b/terraform/account/terraform.tfvars.json
@@ -32,7 +32,6 @@
         "arn:aws:iam::792093328875:role/preproduction-app-task-role",
         "arn:aws:iam::792093328875:role/event-received-preproduction",
         "arn:aws:iam::492687888235:role/api-ecs-adhoc",
-        "arn:aws:iam::492687888235:role/api-ecs-finance",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction",
         "arn:aws:iam::888228022356:role/preproduction-api-task-role"
       ],

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -71,7 +71,6 @@
       "has_fixtures": false,
       "allowed_arns": [
         "arn:aws:iam::492687888235:role/api-ecs-adhoc",
-        "arn:aws:iam::492687888235:role/api-ecs-finance",
         "arn:aws:iam::492687888235:role/api-ecs-preproduction",
         "arn:aws:iam::936779158973:role/breakglass",
         "arn:aws:iam::936779158973:role/lpa-store-ci",


### PR DESCRIPTION
And remove the finance roles from preprod allowed ARNs as they don't exist any more

Fixes SP-2875 #patch
