### PR TITLE
VEGA-2977 : Disable Do Not Register manual update #minor

### DIFF
--- a/lambda/update/opg_change_status.go
+++ b/lambda/update/opg_change_status.go
@@ -13,7 +13,7 @@ type OpgChangeStatus struct {
 func (r OpgChangeStatus) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 	if r.Status != shared.LpaStatusCannotRegister && r.Status != shared.LpaStatusCancelled && r.Status != shared.LpaStatusDoNotRegister && r.Status != shared.LpaStatusExpired {
-		return []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled, do not register or expired"}}
+		return []shared.FieldError{{Source: "/status", Detail: "Lpa cannot be manually updated to this status"}}
 	}
 
 	if r.Status == shared.LpaStatusCannotRegister && lpa.Status == shared.LpaStatusRegistered {

--- a/lambda/update/opg_change_status_test.go
+++ b/lambda/update/opg_change_status_test.go
@@ -69,7 +69,7 @@ func TestOpgChangeStatusInvalidNewStatus(t *testing.T) {
 	}
 
 	errors := c.Apply(lpa)
-	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Status to be updated should be cannot register, cancelled, do not register or expired"}})
+	assert.Equal(t, errors, []shared.FieldError{{Source: "/status", Detail: "Lpa cannot be manually updated to this status"}})
 }
 
 func TestOpgChangeStatusToCannotRegisterIncorrectExistingStatus(t *testing.T) {


### PR DESCRIPTION
# Purpose

This PR is for [VEGA-2977](https://opgtransform.atlassian.net/browse/VEGA-2977). As part of this PR, the error message for manual status update has been made more generic to cater to statuses like Do Not Register which needs to be updated by the `opg_change_status.go` file but cannot be updated manually.

## Approach

The PR changes the error message to a more generic one.

## Learning




[VEGA-2977]: https://opgtransform.atlassian.net/browse/VEGA-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ