### PR TITLE
Remove R&C images when severing R&Cs

### DIFF
--- a/lambda/update/sever_restrictions.go
+++ b/lambda/update/sever_restrictions.go
@@ -11,6 +11,7 @@ type SeverRestrictions struct {
 
 func (r SeverRestrictions) Apply(lpa *shared.Lpa) []shared.FieldError {
 	lpa.RestrictionsAndConditions = r.restrictionsAndConditions
+	lpa.RestrictionsAndConditionsImages = []shared.File{}
 
 	return nil
 }

--- a/lambda/update/sever_restrictions_test.go
+++ b/lambda/update/sever_restrictions_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSeverRestrictionsApply(t *testing.T) {
@@ -28,6 +29,12 @@ func TestSeverRestrictionsApply(t *testing.T) {
 			LpaInit: shared.LpaInit{
 				RestrictionsAndConditions: tc.newRestriction,
 			},
+			RestrictionsAndConditionsImages: []shared.File{
+				{
+					Path: "folder/test.png",
+					Hash: "fake-hash",
+				},
+			},
 		}
 
 		s := SeverRestrictions{
@@ -38,6 +45,7 @@ func TestSeverRestrictionsApply(t *testing.T) {
 			errors := s.Apply(lpa)
 			assert.Empty(t, errors)
 			assert.Equal(t, s.restrictionsAndConditions, lpa.RestrictionsAndConditions)
+			assert.Len(t, lpa.RestrictionsAndConditionsImages, 0)
 		})
 	}
 }


### PR DESCRIPTION
# Purpose

Severance replaces the original R&Cs, so if there were any images then they should be removed and replaced with the new text.

Fixes VEGA-3055 #minor

## Approach

Unset the values during the update to the LPA