### PR TITLE
VEGA-2935 Add Note when attorney removed

### DIFF
--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -43,6 +43,7 @@ type Lpa struct {
 	RegistrationDate                *time.Time `json:"registrationDate,omitempty"`
 	UpdatedAt                       time.Time  `json:"updatedAt"`
 	RestrictionsAndConditionsImages []File     `json:"restrictionsAndConditionsImages,omitempty"`
+	Notes                           []Note     `json:"notes,omitempty"`
 }
 
 type Note map[string]interface{}

--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -45,6 +45,8 @@ type Lpa struct {
 	RestrictionsAndConditionsImages []File     `json:"restrictionsAndConditionsImages,omitempty"`
 }
 
+type Note map[string]interface{}
+
 type LpaType string
 
 const (

--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -76,12 +76,12 @@ func (l LpaStatus) IsValid() bool {
 	return l == LpaStatusInProgress || l == LpaStatusStatutoryWaitingPeriod || l == LpaStatusRegistered || l == LpaStatusCannotRegister || l == LpaStatusWithdrawn || l == LpaStatusCancelled || l == LpaStatusDoNotRegister || l == LpaStatusExpired
 }
 
-func (l Lpa) FindAttorneyIndex(changeKey string) (int, bool) {
-	if idx, err := strconv.Atoi(changeKey); err == nil && idx < len(l.Attorneys) {
+func (lpa *Lpa) FindAttorneyIndex(changeKey string) (int, bool) {
+	if idx, err := strconv.Atoi(changeKey); err == nil && idx < len(lpa.Attorneys) {
 		return idx, true
 	}
 
-	for i, attorney := range l.Attorneys {
+	for i, attorney := range lpa.Attorneys {
 		if attorney.UID == changeKey {
 			return i, true
 		}
@@ -90,16 +90,20 @@ func (l Lpa) FindAttorneyIndex(changeKey string) (int, bool) {
 	return 0, false
 }
 
-func (l Lpa) FindTrustCorporationIndex(changeKey string) (int, bool) {
-	if idx, err := strconv.Atoi(changeKey); err == nil && idx < len(l.TrustCorporations) {
+func (lpa *Lpa) FindTrustCorporationIndex(changeKey string) (int, bool) {
+	if idx, err := strconv.Atoi(changeKey); err == nil && idx < len(lpa.TrustCorporations) {
 		return idx, true
 	}
 
-	for i, tc := range l.TrustCorporations {
+	for i, tc := range lpa.TrustCorporations {
 		if tc.UID == changeKey {
 			return i, true
 		}
 	}
 
 	return 0, false
+}
+
+func (lpa *Lpa) AddNote(note Note) {
+	lpa.Notes = append(lpa.Notes, note)
 }

--- a/lambda/update/change_attorneys.go
+++ b/lambda/update/change_attorneys.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/validate"
@@ -30,6 +31,18 @@ func (a ChangeAttorney) Apply(lpa *shared.Lpa) []shared.FieldError {
 		}
 
 		lpa.Attorneys[*changeAttorneyStatus.Index].Status = changeAttorneyStatus.Status
+
+		if changeAttorneyStatus.Status == shared.AttorneyStatusRemoved {
+			attorneyRemovedNote := shared.Note{
+				"type":     "ATTORNEY_REMOVED_V1",
+				"datetime": time.Now().Format(time.RFC3339),
+				"values": map[string]string{
+					"fullName": lpa.Attorneys[*changeAttorneyStatus.Index].FirstNames + " " + lpa.Attorneys[*changeAttorneyStatus.Index].LastName,
+				},
+			}
+
+			lpa.AddNote(attorneyRemovedNote)
+		}
 	}
 
 	return nil

--- a/lambda/update/change_attorneys_test.go
+++ b/lambda/update/change_attorneys_test.go
@@ -30,6 +30,33 @@ func TestChangeAttorneysApply(t *testing.T) {
 	errors := changeAttorney.Apply(lpa)
 	assert.Empty(t, errors)
 	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
+	assert.Empty(t, lpa.Notes)
+}
+
+func TestChangeAttorneysApplySetAttorneyInactive(t *testing.T) {
+	attorneyIndex := 1
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			Attorneys: []shared.Attorney{
+				{}, {},
+			},
+		},
+	}
+
+	changeAttorney := ChangeAttorney{
+		ChangeAttorneyStatus: []ChangeAttorneyStatus{
+			{
+				Index:  &attorneyIndex,
+				Status: shared.AttorneyStatusRemoved,
+			},
+		},
+	}
+
+	errors := changeAttorney.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
+	assert.Equal(t, 1, len(lpa.Notes))
+	assert.Equal(t, "ATTORNEY_REMOVED_V1", lpa.Notes[0]["type"])
 }
 
 func TestChangeAttorneysIncorrectStatus(t *testing.T) {


### PR DESCRIPTION
# Purpose

Add a Note to the LPA when an attorney is removed.

Fixes [VEGA-2935](https://opgtransform.atlassian.net/browse/VEGA-2935)

## Approach

Add a map to the LPA struct for the notes and a method to add a note. Call this when attorneys are being removed.

## Learning

n/a


[VEGA-2935]: https://opgtransform.atlassian.net/browse/VEGA-2935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ