### PR TITLE
VEGA-2939 : add note when replacement attorney enabled

### DIFF
--- a/lambda/update/change_attorneys.go
+++ b/lambda/update/change_attorneys.go
@@ -43,6 +43,18 @@ func (a ChangeAttorney) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 			lpa.AddNote(attorneyRemovedNote)
 		}
+
+		if changeAttorneyStatus.Status == shared.AttorneyStatusActive && lpa.Attorneys[*changeAttorneyStatus.Index].AppointmentType == shared.AppointmentTypeReplacement {
+			replacementAttorneyEnabledNote := shared.Note{
+				"type":     "REPLACEMENT_ATTORNEY_ENABLED_V1",
+				"datetime": time.Now().Format(time.RFC3339),
+				"values": map[string]string{
+					"fullName": lpa.Attorneys[*changeAttorneyStatus.Index].FirstNames + " " + lpa.Attorneys[*changeAttorneyStatus.Index].LastName,
+				},
+			}
+
+			lpa.AddNote(replacementAttorneyEnabledNote)
+		}
 	}
 
 	return nil

--- a/lambda/update/change_attorneys_test.go
+++ b/lambda/update/change_attorneys_test.go
@@ -198,3 +198,29 @@ func TestValidateUpdateChangeAttorneysWithUIDReferences(t *testing.T) {
 		})
 	}
 }
+
+func TestChangeAttorneysEnableReplacementAttorney(t *testing.T) {
+	attorneyIndex := 1
+	lpa := &shared.Lpa{
+		LpaInit: shared.LpaInit{
+			Attorneys: []shared.Attorney{
+				{}, {AppointmentType: shared.AppointmentTypeReplacement},
+			},
+		},
+	}
+
+	changeAttorney := ChangeAttorney{
+		ChangeAttorneyStatus: []ChangeAttorneyStatus{
+			{
+				Index:  &attorneyIndex,
+				Status: shared.AttorneyStatusActive,
+			},
+		},
+	}
+
+	errors := changeAttorney.Apply(lpa)
+	assert.Empty(t, errors)
+	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
+	assert.Equal(t, 1, len(lpa.Notes))
+	assert.Equal(t, "REPLACEMENT_ATTORNEY_ENABLED_V1", lpa.Notes[0]["type"])
+}


### PR DESCRIPTION
# Purpose

adds a note to the LPA when a replacement-attorneys status is changed to "active"

Fixes: (VEGA-2936)[https://opgtransform.atlassian.net/browse/VEGA-2936]

## Approach

builds on approach used in #360 
