### PR TITLE
VEGA-2915 Add note for restrictions and conditions severance

### DIFF
--- a/lambda/update/change_attorneys_test.go
+++ b/lambda/update/change_attorneys_test.go
@@ -55,7 +55,7 @@ func TestChangeAttorneysApplySetAttorneyInactive(t *testing.T) {
 	errors := changeAttorney.Apply(lpa)
 	assert.Empty(t, errors)
 	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
-	assert.Equal(t, 1, len(lpa.Notes))
+	assert.Len(t, lpa.Notes, 1)
 	assert.Equal(t, "ATTORNEY_REMOVED_V1", lpa.Notes[0]["type"])
 }
 

--- a/lambda/update/change_attorneys_test.go
+++ b/lambda/update/change_attorneys_test.go
@@ -38,7 +38,14 @@ func TestChangeAttorneysApplySetAttorneyInactive(t *testing.T) {
 	lpa := &shared.Lpa{
 		LpaInit: shared.LpaInit{
 			Attorneys: []shared.Attorney{
-				{}, {},
+				{Person: shared.Person{
+					FirstNames: "Arun",
+					LastName:   "Brar",
+				}},
+				{Person: shared.Person{
+					FirstNames: "Charles",
+					LastName:   "Dent",
+				}},
 			},
 		},
 	}
@@ -53,10 +60,14 @@ func TestChangeAttorneysApplySetAttorneyInactive(t *testing.T) {
 	}
 
 	errors := changeAttorney.Apply(lpa)
+
+	noteValues := lpa.Notes[0]["values"].(map[string]string)
+
 	assert.Empty(t, errors)
 	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
 	assert.Len(t, lpa.Notes, 1)
 	assert.Equal(t, "ATTORNEY_REMOVED_V1", lpa.Notes[0]["type"])
+	assert.Equal(t, "Charles Dent", noteValues["fullName"])
 }
 
 func TestChangeAttorneysIncorrectStatus(t *testing.T) {

--- a/lambda/update/sever_restrictions.go
+++ b/lambda/update/sever_restrictions.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
 	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
 )
@@ -12,6 +14,24 @@ type SeverRestrictions struct {
 func (r SeverRestrictions) Apply(lpa *shared.Lpa) []shared.FieldError {
 	lpa.RestrictionsAndConditions = r.restrictionsAndConditions
 	lpa.RestrictionsAndConditionsImages = []shared.File{}
+
+	var updatedRestrictionsAndConditions string
+
+	if lpa.RestrictionsAndConditions == "" {
+		updatedRestrictionsAndConditions = "All restrictions have been severed from the LPA"
+	} else {
+		updatedRestrictionsAndConditions = lpa.RestrictionsAndConditions
+	}
+
+	severRestrictionsAndConditionsNote := shared.Note{
+		"type":     "SEVER_RESTRICTIONS_AND_CONDITIONS_V1",
+		"datetime": time.Now().Format(time.RFC3339),
+		"values": map[string]string{
+			"updatedRestrictionsAndConditions": updatedRestrictionsAndConditions,
+		},
+	}
+
+	lpa.AddNote(severRestrictionsAndConditionsNote)
 
 	return nil
 }


### PR DESCRIPTION
# Purpose

Adds a Note when restrictions and conditions are severed.

Fixes [VEGA-2915](https://opgtransform.atlassian.net/browse/VEGA-2915)

## Approach

Uses LPA `AddNote` method.

## Learning

Use `Object.(type)` to type check an interface and get its value.


[VEGA-2915]: https://opgtransform.atlassian.net/browse/VEGA-2915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ