### PR TITLE
VEGA-2938 Add note for certificateProvider name change

### DIFF
--- a/internal/shared/lpa.go
+++ b/internal/shared/lpa.go
@@ -46,7 +46,11 @@ type Lpa struct {
 	Notes                           []Note     `json:"notes,omitempty"`
 }
 
-type Note map[string]interface{}
+type Note struct {
+	Type     string            `json:"type"`
+	Datetime string            `json:"datetime"`
+	Values   map[string]string `json:"values"`
+}
 
 type LpaType string
 

--- a/lambda/update/change_attorneys.go
+++ b/lambda/update/change_attorneys.go
@@ -34,9 +34,9 @@ func (a ChangeAttorney) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 		if changeAttorneyStatus.Status == shared.AttorneyStatusRemoved {
 			attorneyRemovedNote := shared.Note{
-				"type":     "ATTORNEY_REMOVED_V1",
-				"datetime": time.Now().Format(time.RFC3339),
-				"values": map[string]string{
+				Type:     "ATTORNEY_REMOVED_V1",
+				Datetime: time.Now().Format(time.RFC3339),
+				Values: map[string]string{
 					"fullName": lpa.Attorneys[*changeAttorneyStatus.Index].FirstNames + " " + lpa.Attorneys[*changeAttorneyStatus.Index].LastName,
 				},
 			}
@@ -46,9 +46,9 @@ func (a ChangeAttorney) Apply(lpa *shared.Lpa) []shared.FieldError {
 
 		if changeAttorneyStatus.Status == shared.AttorneyStatusActive && lpa.Attorneys[*changeAttorneyStatus.Index].AppointmentType == shared.AppointmentTypeReplacement {
 			replacementAttorneyEnabledNote := shared.Note{
-				"type":     "REPLACEMENT_ATTORNEY_ENABLED_V1",
-				"datetime": time.Now().Format(time.RFC3339),
-				"values": map[string]string{
+				Type:     "REPLACEMENT_ATTORNEY_ENABLED_V1",
+				Datetime: time.Now().Format(time.RFC3339),
+				Values: map[string]string{
 					"fullName": lpa.Attorneys[*changeAttorneyStatus.Index].FirstNames + " " + lpa.Attorneys[*changeAttorneyStatus.Index].LastName,
 				},
 			}

--- a/lambda/update/change_attorneys_test.go
+++ b/lambda/update/change_attorneys_test.go
@@ -61,13 +61,11 @@ func TestChangeAttorneysApplySetAttorneyInactive(t *testing.T) {
 
 	errors := changeAttorney.Apply(lpa)
 
-	noteValues := lpa.Notes[0]["values"].(map[string]string)
-
 	assert.Empty(t, errors)
 	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
 	assert.Len(t, lpa.Notes, 1)
-	assert.Equal(t, "ATTORNEY_REMOVED_V1", lpa.Notes[0]["type"])
-	assert.Equal(t, "Charles Dent", noteValues["fullName"])
+	assert.Equal(t, "ATTORNEY_REMOVED_V1", lpa.Notes[0].Type)
+	assert.Equal(t, "Charles Dent", lpa.Notes[0].Values["fullName"])
 }
 
 func TestChangeAttorneysIncorrectStatus(t *testing.T) {
@@ -243,11 +241,9 @@ func TestChangeAttorneysEnableReplacementAttorney(t *testing.T) {
 
 	errors := changeAttorney.Apply(lpa)
 
-	noteValues := lpa.Notes[0]["values"].(map[string]string)
-
 	assert.Empty(t, errors)
 	assert.Equal(t, changeAttorney.ChangeAttorneyStatus[0].Status, lpa.Attorneys[attorneyIndex].Status)
 	assert.Len(t, lpa.Notes, 1)
-	assert.Equal(t, "REPLACEMENT_ATTORNEY_ENABLED_V1", lpa.Notes[0]["type"])
-	assert.Equal(t, "Charles Dent", noteValues["fullName"])
+	assert.Equal(t, "REPLACEMENT_ATTORNEY_ENABLED_V1", lpa.Notes[0].Type)
+	assert.Equal(t, "Charles Dent", lpa.Notes[0].Values["fullName"])
 }

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -63,6 +63,19 @@ func (c CertificateProviderCorrection) Apply(lpa *shared.Lpa) []shared.FieldErro
 		}}
 	}
 
+	if lpa.CertificateProvider.FirstNames != c.FirstNames || lpa.CertificateProvider.LastName != c.LastName {
+		nameChangeNote := shared.Note{
+			"type":     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
+			"datetime": time.Now().Format(time.RFC3339),
+			"values": map[string]string{
+				"oldName": lpa.CertificateProvider.FirstNames + " " + lpa.CertificateProvider.LastName,
+				"newName": c.FirstNames + " " + c.LastName,
+			},
+		}
+
+		lpa.AddNote(nameChangeNote)
+	}
+
 	lpa.CertificateProvider.FirstNames = c.FirstNames
 	lpa.CertificateProvider.LastName = c.LastName
 	lpa.CertificateProvider.Address = c.Address

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -65,9 +65,9 @@ func (c CertificateProviderCorrection) Apply(lpa *shared.Lpa) []shared.FieldErro
 
 	if lpa.CertificateProvider.FirstNames != c.FirstNames || lpa.CertificateProvider.LastName != c.LastName {
 		nameChangeNote := shared.Note{
-			"type":     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
-			"datetime": time.Now().Format(time.RFC3339),
-			"values": map[string]string{
+			Type:     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
+			Datetime: time.Now().Format(time.RFC3339),
+			Values: map[string]string{
 				"oldName": lpa.CertificateProvider.FirstNames + " " + lpa.CertificateProvider.LastName,
 				"newName": c.FirstNames + " " + c.LastName,
 			},

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -21,6 +21,7 @@ func ptrTo[T any](v T) *T {
 
 func TestCorrectionApply(t *testing.T) {
 	now := time.Now()
+	nowFormatted := time.Now().Format(time.RFC3339)
 	yesterday := now.AddDate(0, 0, -1)
 	twoDaysAgo := time.Now().AddDate(0, 0, -2)
 
@@ -61,7 +62,7 @@ func TestCorrectionApply(t *testing.T) {
 			},
 			errors: []shared.FieldError{{Source: "/signedAt", Detail: "LPA Signed on date cannot be changed for online LPAs"}},
 		},
-		"decisions correcton": {
+		"decisions correction": {
 			correction: Correction{
 				HowAttorneysMakeDecisions:                   shared.HowMakeDecisionsJointlyForSomeSeverallyForOthers,
 				HowAttorneysMakeDecisionsDetails:            "this way",
@@ -101,7 +102,7 @@ func TestCorrectionApply(t *testing.T) {
 				},
 			},
 		},
-		"donor correcton": {
+		"donor correction": {
 			correction: Correction{
 				Donor: DonorCorrection{
 					FirstNames:        "Jane",
@@ -218,6 +219,14 @@ func TestCorrectionApply(t *testing.T) {
 						SignedAt: &yesterday,
 					},
 				},
+				Notes: []shared.Note{{
+					"type":     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
+					"datetime": nowFormatted,
+					"values": map[string]string{
+						"oldName": "Branson Conn",
+						"newName": "Lynn Christiansen",
+					},
+				}},
 			},
 		},
 		"certificate provider cannot change signed at": {

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -220,9 +220,9 @@ func TestCorrectionApply(t *testing.T) {
 					},
 				},
 				Notes: []shared.Note{{
-					"type":     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
-					"datetime": nowFormatted,
-					"values": map[string]string{
+					Type:     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
+					Datetime: nowFormatted,
+					Values: map[string]string{
 						"oldName": "Branson Conn",
 						"newName": "Lynn Christiansen",
 					},

--- a/lambda/update/sever_restrictions.go
+++ b/lambda/update/sever_restrictions.go
@@ -24,9 +24,9 @@ func (r SeverRestrictions) Apply(lpa *shared.Lpa) []shared.FieldError {
 	}
 
 	severRestrictionsAndConditionsNote := shared.Note{
-		"type":     "SEVER_RESTRICTIONS_AND_CONDITIONS_V1",
-		"datetime": time.Now().Format(time.RFC3339),
-		"values": map[string]string{
+		Type:     "SEVER_RESTRICTIONS_AND_CONDITIONS_V1",
+		Datetime: time.Now().Format(time.RFC3339),
+		Values: map[string]string{
 			"updatedRestrictionsAndConditions": updatedRestrictionsAndConditions,
 		},
 	}

--- a/lambda/update/sever_restrictions_test.go
+++ b/lambda/update/sever_restrictions_test.go
@@ -46,15 +46,13 @@ func TestSeverRestrictionsApply(t *testing.T) {
 		t.Run(scenario, func(t *testing.T) {
 			errors := s.Apply(lpa)
 
-			noteValues := lpa.Notes[0]["values"].(map[string]string)
-
 			assert.Empty(t, errors)
 			assert.Equal(t, tc.newRestriction, lpa.RestrictionsAndConditions)
 			assert.Len(t, lpa.RestrictionsAndConditionsImages, 0)
 			assert.Len(t, lpa.Notes, 1)
-			assert.Equal(t, "SEVER_RESTRICTIONS_AND_CONDITIONS_V1", lpa.Notes[0]["type"])
-			assert.Len(t, noteValues, 1)
-			assert.Equal(t, tc.updatedRestrictionsAndConditions, noteValues["updatedRestrictionsAndConditions"])
+			assert.Equal(t, "SEVER_RESTRICTIONS_AND_CONDITIONS_V1", lpa.Notes[0].Type)
+			assert.Len(t, lpa.Notes[0].Values, 1)
+			assert.Equal(t, tc.updatedRestrictionsAndConditions, lpa.Notes[0].Values["updatedRestrictionsAndConditions"])
 		})
 	}
 }


### PR DESCRIPTION
# Purpose

Adds a note for when the certificateProvider changes either first or surname

Fixes [vega-2938](https://opgtransform.atlassian.net/browse/VEGA-2938)

## Approach

Explain how your code addresses the purpose of the change

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service
