### PR TITLE
VEGA-2937 : Add a static note when donor's name is updated #minor

### DIFF
--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -80,7 +80,6 @@ func (c CertificateProviderCorrection) Apply(lpa *shared.Lpa) []shared.FieldErro
 			Type:     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
 			Datetime: time.Now().Format(time.RFC3339),
 			Values: map[string]string{
-				"oldName": lpa.CertificateProvider.FirstNames + " " + lpa.CertificateProvider.LastName,
 				"newName": c.FirstNames + " " + c.LastName,
 			},
 		}

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -36,6 +36,18 @@ type DonorCorrection struct {
 }
 
 func (c DonorCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
+	if lpa.Donor.FirstNames != c.FirstNames || lpa.Donor.LastName != c.LastName {
+		donorNameChangeNote := shared.Note{
+			Type:     "DONOR_NAME_CHANGE_V1",
+			Datetime: time.Now().Format(time.RFC3339),
+			Values: map[string]string{
+				"newName": c.FirstNames + " " + c.LastName,
+			},
+		}
+
+		lpa.AddNote(donorNameChangeNote)
+	}
+
 	lpa.Donor.FirstNames = c.FirstNames
 	lpa.Donor.LastName = c.LastName
 	lpa.Donor.OtherNamesKnownBy = c.OtherNamesKnownBy

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -163,6 +163,13 @@ func TestCorrectionApply(t *testing.T) {
 					},
 					Attorneys: []shared.Attorney{},
 				},
+				Notes: []shared.Note{{
+					Type:     "DONOR_NAME_CHANGE_V1",
+					Datetime: nowFormatted,
+					Values: map[string]string{
+						"newName": "Jane Smith",
+					},
+				}},
 			},
 		},
 		"certificate provider correction": {

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -230,7 +230,6 @@ func TestCorrectionApply(t *testing.T) {
 					Type:     "CERTIFICATE_PROVIDER_NAME_CHANGE_V1",
 					Datetime: nowFormatted,
 					Values: map[string]string{
-						"oldName": "Branson Conn",
 						"newName": "Lynn Christiansen",
 					},
 				}},


### PR DESCRIPTION
# Purpose

This PR covers [VEGA-2937](https://opgtransform.atlassian.net/browse/VEGA-2937) which adds a static note to the LPA when the donor's name is changed.

## Approach

Explain how your code addresses the purpose of the change

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service


[VEGA-2937]: https://opgtransform.atlassian.net/browse/VEGA-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ