### PR TITLE
VEGA-3101: record Notes on LPA when donor's DOB is changed

### DIFF
--- a/internal/shared/date.go
+++ b/internal/shared/date.go
@@ -65,3 +65,10 @@ func (d Date) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
 
 	return attributevalue.Marshal(string(bytes))
 }
+
+func (d Date) DateOnlyText() string {
+	if d.t.IsZero() {
+		return ""
+	}
+	return d.t.Format(time.DateOnly)
+}

--- a/internal/shared/date_test.go
+++ b/internal/shared/date_test.go
@@ -101,3 +101,41 @@ func TestDateDynamoDB(t *testing.T) {
 		})
 	}
 }
+
+func TestDateOnlyText(t *testing.T) {
+	testcases := map[string]struct {
+		date     Date
+		expected string
+	}{
+		"valid date": {
+			date:     Date{t: time.Date(2000, time.November, 11, 0, 0, 0, 0, time.UTC)},
+			expected: "2000-11-11",
+		},
+		"different valid date": {
+			date:     Date{t: time.Date(1985, time.May, 15, 0, 0, 0, 0, time.UTC)},
+			expected: "1985-05-15",
+		},
+		"zero date": {
+			date:     Date{},
+			expected: "",
+		},
+		"malformed date but valid time": {
+			date: Date{
+				t:           time.Date(2023, time.December, 25, 0, 0, 0, 0, time.UTC),
+				IsMalformed: true,
+			},
+			expected: "2023-12-25",
+		},
+		"leap year": {
+			date:     Date{t: time.Date(2000, time.February, 29, 0, 0, 0, 0, time.UTC)},
+			expected: "2000-02-29",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			result := tc.date.DateOnlyText()
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -49,15 +49,12 @@ func (c DonorCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
 	}
 
 	if lpa.Donor.DateOfBirth != c.DateOfBirth {
-		oldDobBytes, _ := lpa.Donor.DateOfBirth.MarshalText()
-		newDobBytes, _ := c.DateOfBirth.MarshalText()
-
 		donorDobChangeNote := shared.Note{
 			Type:     "DONOR_DOB_CHANGE_V1",
 			Datetime: time.Now().Format(time.RFC3339),
 			Values: map[string]string{
-				"oldDob": string(oldDobBytes),
-				"newDob": string(newDobBytes),
+				"oldDob": lpa.Donor.DateOfBirth.DateOnlyText(),
+				"newDob": c.DateOfBirth.DateOnlyText(),
 			},
 		}
 

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -48,6 +48,22 @@ func (c DonorCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
 		lpa.AddNote(donorNameChangeNote)
 	}
 
+	if lpa.Donor.DateOfBirth != c.DateOfBirth {
+		oldDobBytes, _ := lpa.Donor.DateOfBirth.MarshalText()
+		newDobBytes, _ := c.DateOfBirth.MarshalText()
+
+		donorDobChangeNote := shared.Note{
+			Type:     "DONOR_DOB_CHANGE_V1",
+			Datetime: time.Now().Format(time.RFC3339),
+			Values: map[string]string{
+				"oldDob": string(oldDobBytes),
+				"newDob": string(newDobBytes),
+			},
+		}
+
+		lpa.AddNote(donorDobChangeNote)
+	}
+
 	lpa.Donor.FirstNames = c.FirstNames
 	lpa.Donor.LastName = c.LastName
 	lpa.Donor.OtherNamesKnownBy = c.OtherNamesKnownBy

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -163,13 +163,23 @@ func TestCorrectionApply(t *testing.T) {
 					},
 					Attorneys: []shared.Attorney{},
 				},
-				Notes: []shared.Note{{
-					Type:     "DONOR_NAME_CHANGE_V1",
-					Datetime: nowFormatted,
-					Values: map[string]string{
-						"newName": "Jane Smith",
+				Notes: []shared.Note{
+					{
+						Type:     "DONOR_NAME_CHANGE_V1",
+						Datetime: nowFormatted,
+						Values: map[string]string{
+							"newName": "Jane Smith",
+						},
 					},
-				}},
+					{
+						Type:     "DONOR_DOB_CHANGE_V1",
+						Datetime: nowFormatted,
+						Values: map[string]string{
+							"oldDob": "1990-01-02",
+							"newDob": "2000-11-11",
+						},
+					},
+				},
 			},
 		},
 		"certificate provider correction": {


### PR DESCRIPTION
# VEGA-3101: Record Notes on LPA when donor's DOB is changed

## Summary
Implements note recording functionality when a donor's date of birth is updated in the LPA store, as required by ticket VEGA-3101.

## Changes Made

### Core Implementation
- **`correction.go`**: Added DOB change detection in `DonorCorrection.Apply()` method
  - Records note with type `"DONOR_DOB_CHANGE_V1"` when donor DOB changes
  - Captures both old and new DOB values with timestamp
  - Follows the same pattern as existing name change functionality

### Helper Method Addition  
- **`date.go`**: Added `DateOnlyText()` helper method to `Date` type
  - Provides clean, readable way to convert `shared.Date` to string
  - Handles zero dates appropriately (returns empty string)
  - Uses Go's `time.DateOnly` format for consistency

### Test Updates
- **`correction_test.go`**: Updated existing "donor correction" test case
  - Now expects both name change and DOB change notes since test modifies both fields

- **`date_test.go`**: Added comprehensive tests for `DateOnlyText()` method
  - Tests valid dates, zero dates, malformed dates, and edge cases
  - Ensures consistent string formatting across all scenarios

## Technical Details

### Note Structure
```go
{
    Type:     "DONOR_DOB_CHANGE_V1",
    Datetime: "2025-07-29T10:12:37+01:00",
    Values: map[string]string{
        "oldDob": "1990-01-02",
        "newDob": "2000-11-11",
    },
}
```

### Usage
The new helper method simplifies date-to-string conversion:
```go
// Before: complex MarshalText() approach
oldDobBytes, _ := lpa.Donor.DateOfBirth.MarshalText()
oldDob := string(oldDobBytes)

// After: clean helper method
oldDob := lpa.Donor.DateOfBirth.DateOnlyText()
```

## Testing
- ✅ All existing tests pass
- ✅ New functionality covered by tests
- ✅ Edge cases handled (zero dates, malformed dates)
- ✅ Integration with existing note recording system

## Acceptance Criteria Met
- [x] Records note when donor DOB is updated (any status except Draft)
- [x] Note includes date of change (timestamp)
- [x] Note includes both old and new DOB values

## Related
- Follows same pattern as VEGA-2937 (donor name changes)
- Part of broader LPA audit trail requirements