### PR TITLE
VEGA-2751 do not allow donor dob change after identity check

### DIFF
--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -36,6 +36,13 @@ type DonorCorrection struct {
 }
 
 func (c DonorCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
+	if lpa.Donor.IdentityCheck != nil && !c.DateOfBirth.IsZero() && c.DateOfBirth != lpa.Donor.DateOfBirth {
+		return []shared.FieldError{{
+			Source: "/donor/dateOfBirth",
+			Detail: "The donor's date of birth cannot be changed once the identity check is complete",
+		}}
+	}
+
 	if lpa.Donor.FirstNames != c.FirstNames || lpa.Donor.LastName != c.LastName {
 		donorNameChangeNote := shared.Note{
 			Type:     "DONOR_NAME_CHANGE_V1",

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -36,7 +36,10 @@ type DonorCorrection struct {
 }
 
 func (c DonorCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
-	if lpa.Donor.IdentityCheck != nil && !c.DateOfBirth.IsZero() && c.DateOfBirth != lpa.Donor.DateOfBirth {
+	isIdCheckComplete := lpa.Donor.IdentityCheck != nil
+	isDobChangeRequested := !c.DateOfBirth.IsZero() && c.DateOfBirth != lpa.Donor.DateOfBirth
+
+	if isIdCheckComplete && isDobChangeRequested {
 		return []shared.FieldError{{
 			Source: "/donor/dateOfBirth",
 			Detail: "The donor's date of birth cannot be changed once the identity check is complete",

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -181,6 +181,26 @@ func TestCorrectionApply(t *testing.T) {
 				},
 			},
 		},
+		"donor date of birth cannot change after identity check": {
+			correction: Correction{
+				Donor: DonorCorrection{
+					DateOfBirth: createDate("2000-11-11"),
+				},
+			},
+			lpa: &shared.Lpa{
+				LpaInit: shared.LpaInit{
+					Channel: "online",
+					Donor: shared.Donor{
+						DateOfBirth: createDate("2002-12-12"),
+						IdentityCheck: &shared.IdentityCheck{
+							CheckedAt: yesterday,
+							Type:      shared.IdentityCheckTypeOneLogin,
+						},
+					},
+				},
+			},
+			errors: []shared.FieldError{{Source: "/donor/dateOfBirth", Detail: "The donor's date of birth cannot be changed once the identity check is complete"}},
+		},
 		"certificate provider correction": {
 			correction: Correction{
 				CertificateProvider: CertificateProviderCorrection{


### PR DESCRIPTION
# Purpose

PR to prevent the donor's date of birth to be changed once the identity check has been made on the donor.

Fixes (VEGA-2751)

## Approach

Returns FieldError if a donor date of birth change is being made and the identity check checked at field has already been set.
