### PR TITLE
VEGA-3212 : Add a new change type for post registration corrections

### DIFF
--- a/lambda/update/post_registration_correction.go
+++ b/lambda/update/post_registration_correction.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"github.com/ministryofjustice/opg-data-lpa-store/internal/shared"
+	"github.com/ministryofjustice/opg-data-lpa-store/lambda/update/parse"
+)
+
+type PostRegistrationCorrection struct {
+	Donor DonorPostRegistrationCorrection
+}
+
+type DonorPostRegistrationCorrection struct {
+	FirstNames string
+}
+
+func (c DonorPostRegistrationCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
+	lpa.Donor.FirstNames = c.FirstNames
+
+	return nil
+}
+
+func (c PostRegistrationCorrection) Apply(lpa *shared.Lpa) []shared.FieldError {
+	if fieldErrors := c.Donor.Apply(lpa); len(fieldErrors) > 0 {
+		return fieldErrors
+	}
+
+	return nil
+}
+
+func validatePostRegistrationCorrection(changes []shared.Change, lpa *shared.Lpa) (PostRegistrationCorrection, []shared.FieldError) {
+	var data PostRegistrationCorrection
+
+	parser := parse.Changes(changes)
+	errors := parser.Consumed()
+
+	return data, errors
+}

--- a/lambda/update/post_registration_correction_test.go
+++ b/lambda/update/post_registration_correction_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestPostRegistrationCorrectionApply(t *testing.T) {
+
+}

--- a/lambda/update/validate.go
+++ b/lambda/update/validate.go
@@ -46,6 +46,8 @@ func validateUpdate(update shared.Update, lpa *shared.Lpa) (Applyable, []shared.
 		return validatePaperCertificateProviderAccessOnline(update.Changes)
 	case "PAPER_ATTORNEY_ACCESS_ONLINE":
 		return validatePaperAttorneyAccessOnline(update.Changes, lpa)
+	case "POST_REGISTRATION_CORRECTION":
+		return validatePostRegistrationCorrection(update.Changes, lpa)
 	default:
 		return nil, []shared.FieldError{{Source: "/type", Detail: "invalid value"}}
 	}


### PR DESCRIPTION
This PR covers [VEGA-3212](https://opgtransform.atlassian.net/browse/VEGA-3212)

As part of this PR, a new change type has been added to accommodate post registration corrections for a signed LPA. At the moment, just the change type has been added with a new class for it and there is no logic or tests around it. There are tickets after this which will incorporate logic into the corrections and at that time, there will be more exhaustive tests to cover the implementation for all the relevant actors of the LPA.

[VEGA-3212]: https://opgtransform.atlassian.net/browse/VEGA-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ