### PR TITLE
VEGA-3213 Allow trust corporation details update

### DIFF
--- a/internal/shared/actor_correction.go
+++ b/internal/shared/actor_correction.go
@@ -40,7 +40,7 @@ type TrustCorporationCorrection struct {
 	Email         string
 	Address       Address
 	Mobile        string
-	Signatories   [2]Signatory
+	Signatories   []Signatory
 }
 
 type AttorneyAppointmentTypeCorrection struct {

--- a/lambda/update/correction.go
+++ b/lambda/update/correction.go
@@ -291,7 +291,7 @@ func validateCorrection(changes []shared.Change, lpa *shared.Lpa) (Correction, [
 					data.TrustCorporation.Email = lpa.TrustCorporations[i].Email
 					data.TrustCorporation.Address = lpa.TrustCorporations[i].Address
 					data.TrustCorporation.Mobile = lpa.TrustCorporations[i].Mobile
-					data.TrustCorporation.Signatories = [2]shared.Signatory(lpa.TrustCorporations[i].Signatories[:2])
+					data.TrustCorporation.Signatories = lpa.TrustCorporations[i].Signatories[:]
 
 					return validateTrustCorporation(&data.TrustCorporation, p)
 				}).

--- a/lambda/update/correction_test.go
+++ b/lambda/update/correction_test.go
@@ -375,7 +375,7 @@ func TestCorrectionApply(t *testing.T) {
 							Country:  "GB",
 						},
 						Mobile: "0809 694 3813",
-						Signatories: [2]shared.Signatory{{
+						Signatories: []shared.Signatory{{
 							FirstNames:        "Raphael",
 							LastName:          "Hansen",
 							ProfessionalTitle: "Prof.",
@@ -834,9 +834,7 @@ func TestValidateCorrection(t *testing.T) {
 					Donor:               shared.Donor{},
 					Attorneys:           []shared.Attorney{{}},
 					CertificateProvider: shared.CertificateProvider{},
-					TrustCorporations: []shared.TrustCorporation{{
-						Signatories: []shared.Signatory{{}, {}},
-					}},
+					TrustCorporations:   []shared.TrustCorporation{{}},
 				},
 			},
 			errors: []shared.FieldError{
@@ -891,9 +889,7 @@ func TestValidateCorrection(t *testing.T) {
 					CertificateProvider: shared.CertificateProvider{
 						Address: shared.Address{},
 					},
-					TrustCorporations: []shared.TrustCorporation{{
-						Signatories: []shared.Signatory{{}, {}},
-					}},
+					TrustCorporations: []shared.TrustCorporation{{}},
 				},
 			},
 			errors: []shared.FieldError{
@@ -1051,7 +1047,7 @@ func TestValidateCorrection(t *testing.T) {
 							Postcode: "DB2 2RT",
 							Country:  "GB",
 						},
-						Signatories: [2]shared.Signatory{
+						Signatories: []shared.Signatory{
 							{
 								FirstNames: "Charlie",
 								LastName:   "Pollich",


### PR DESCRIPTION
# Purpose

[VEGA-3213](https://opgtransform.atlassian.net/browse/VEGA-3213) Add support for Trust Corporation corrections.

## Approach

Update corrections and add trust corporation pre-registration correction type. Also add check for certificate provider SignedAt date so we don't needlessly set it to an empty Time pointer when it should be nil.

## Learning

n/a


[VEGA-3213]: https://opgtransform.atlassian.net/browse/VEGA-3213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ