### PR TITLE
VEGA-3107: added route for mocking/fetching changes/updates

### DIFF
--- a/mock-apigw/main.go
+++ b/mock-apigw/main.go
@@ -19,6 +19,7 @@ import (
 var LPAPath = regexp.MustCompile("^/lpas/(M(?:-[0-9A-Z]{4}){3})$")
 var UpdatePath = regexp.MustCompile("^/lpas/(M(?:-[0-9A-Z]{4}){3})/updates$")
 var GetStaticPath = regexp.MustCompile("^/lpas/(M(?:-[0-9A-Z]{4}){3})/static$")
+var ChangesPath = regexp.MustCompile("^/lpas/(M(?:-[0-9A-Z]{4}){3})/changes$")
 var uidMap = map[string]string{}
 
 func delegateHandler(w http.ResponseWriter, r *http.Request) {
@@ -62,6 +63,9 @@ func delegateHandler(w http.ResponseWriter, r *http.Request) {
 	} else if GetStaticPath.MatchString(r.URL.Path) && r.Method == http.MethodGet {
 		uid = GetStaticPath.FindStringSubmatch(r.URL.Path)[1]
 		lambdaName = "getstatic"
+	} else if ChangesPath.MatchString(r.URL.Path) && r.Method == http.MethodGet {
+		uid = ChangesPath.FindStringSubmatch(r.URL.Path)[1]
+		lambdaName = "getupdates"
 	}
 
 	if newUID, ok := uidMap[uid]; ok {


### PR DESCRIPTION
# Purpose

[VEGA-3107](https://opgtransform.atlassian.net/browse/VEGA-3107)

Fixes (Ticket Reference)

## Approach

Added the correct mocked endpoint changes for local dev



[VEGA-3107]: https://opgtransform.atlassian.net/browse/VEGA-3107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ