### PR TITLE
Add support for Pact setup state

### DIFF
--- a/scripts/make_jwt.go
+++ b/scripts/make_jwt.go
@@ -14,7 +14,7 @@ func main() {
 		"exp": time.Now().Add(time.Hour * 24).Unix(),
 		"iat": time.Now().Add(time.Hour * -24).Unix(),
 		"iss": "opg.poas.sirius",
-		"sub": "urn:opg:poas:sirius:users:34",
+		"sub": "urn:opg:sirius:users:34",
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)


### PR DESCRIPTION
`An LPA with UID (M-[A-Z0-9-]+) exists and has changes`

I broke out the `createLPA` method to reuse it across multiple setup states

#patch