### PR TITLE
turn off scheduled metrics key rotation

### DIFF
--- a/.github/workflows/schedule-update-opg-metrics-credentials.yml
+++ b/.github/workflows/schedule-update-opg-metrics-credentials.yml
@@ -2,8 +2,8 @@ name: "[Scheduled] Update OPG Metrics API key"
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '10 2 * * *' # Every 2:10 a.m.
+  # schedule:
+  #   - cron: '10 2 * * *' # Every 2:10 a.m.
 
 permissions:
   contents: write

--- a/.github/workflows/workflow-pr.yml
+++ b/.github/workflows/workflow-pr.yml
@@ -111,6 +111,7 @@ jobs:
             default_role: ${{ vars.PRODUCTION_PULL_REQUEST_ROLE }}
             management_role: ${{ vars.MANAGEMENT_ROLE }}
             backup_role: ${{ vars.BACKUP_PULL_REQUEST_ROLE }}
+
     name: "TF Plan Environment: ${{ matrix.workspace_name }}"
     needs: [generate-tag]
     uses: ./.github/workflows/env-deploy.yml

--- a/terraform/account/opg_metrics.tf
+++ b/terraform/account/opg_metrics.tf
@@ -1,45 +1,45 @@
-data "aws_default_tags" "current" {
-  provider = aws.eu_west_1
-}
+# data "aws_default_tags" "current" {
+#   provider = aws.eu_west_1
+# }
 
-data "aws_secretsmanager_secret" "opg_metrics_api_key" {
-  name     = "opg-metrics-api-key/lpa-store-${data.aws_default_tags.current.tags.account}"
-  provider = aws.shared_eu_west_1
-}
+# data "aws_secretsmanager_secret" "opg_metrics_api_key" {
+#   name     = "opg-metrics-api-key/lpa-store-${data.aws_default_tags.current.tags.account}"
+#   provider = aws.shared_eu_west_1
+# }
 
-data "aws_secretsmanager_secret_version" "opg_metrics_api_key" {
-  secret_id     = data.aws_secretsmanager_secret.opg_metrics_api_key.id
-  version_stage = "AWSCURRENT"
-  provider      = aws.shared_eu_west_1
-}
+# data "aws_secretsmanager_secret_version" "opg_metrics_api_key" {
+#   secret_id     = data.aws_secretsmanager_secret.opg_metrics_api_key.id
+#   version_stage = "AWSCURRENT"
+#   provider      = aws.shared_eu_west_1
+# }
 
-resource "aws_cloudwatch_event_connection" "opg_metrics" {
-  name               = "opg-metrics"
-  description        = "Account level - connection and auth for opg-metrics"
-  authorization_type = "API_KEY"
+# resource "aws_cloudwatch_event_connection" "opg_metrics" {
+#   name               = "opg-metrics"
+#   description        = "Account level - connection and auth for opg-metrics"
+#   authorization_type = "API_KEY"
 
-  auth_parameters {
-    api_key {
-      key   = "x-api-key"
-      value = data.aws_secretsmanager_secret_version.opg_metrics_api_key.secret_string
-    }
-  }
-  provider = aws.eu_west_1
-}
+#   auth_parameters {
+#     api_key {
+#       key   = "x-api-key"
+#       value = data.aws_secretsmanager_secret_version.opg_metrics_api_key.secret_string
+#     }
+#   }
+#   provider = aws.eu_west_1
+# }
 
-resource "aws_cloudwatch_event_api_destination" "opg_metrics_put" {
-  name                             = "opg-metrics-put"
-  description                      = "Account level - an endpoint to push metrics to"
-  invocation_endpoint              = "${local.account.opg_metrics_endpoint}/metrics"
-  http_method                      = "PUT"
-  invocation_rate_limit_per_second = 300
-  connection_arn                   = aws_cloudwatch_event_connection.opg_metrics.arn
-  provider                         = aws.eu_west_1
-}
+# resource "aws_cloudwatch_event_api_destination" "opg_metrics_put" {
+#   name                             = "opg-metrics-put"
+#   description                      = "Account level - an endpoint to push metrics to"
+#   invocation_endpoint              = "${local.account.opg_metrics_endpoint}/metrics"
+#   http_method                      = "PUT"
+#   invocation_rate_limit_per_second = 300
+#   connection_arn                   = aws_cloudwatch_event_connection.opg_metrics.arn
+#   provider                         = aws.eu_west_1
+# }
 
-resource "aws_ssm_parameter" "opg_metrics_arn" {
-  name     = "opg-metrics-api-destination-arn"
-  type     = "String"
-  value    = aws_cloudwatch_event_api_destination.opg_metrics_put.arn
-  provider = aws.eu_west_1
-}
+# resource "aws_ssm_parameter" "opg_metrics_arn" {
+#   name     = "opg-metrics-api-destination-arn"
+#   type     = "String"
+#   value    = aws_cloudwatch_event_api_destination.opg_metrics_put.arn
+#   provider = aws.eu_west_1
+# }

--- a/terraform/account/terraform.tf
+++ b/terraform/account/terraform.tf
@@ -81,16 +81,16 @@ provider "aws" {
   }
 }
 
-provider "aws" {
-  alias  = "shared_eu_west_1"
-  region = "eu-west-1"
+# provider "aws" {
+#   alias  = "shared_eu_west_1"
+#   region = "eu-west-1"
 
-  assume_role {
-    role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.shared_role}"
-    session_name = "lpa-store-terraform-session"
-  }
+#   assume_role {
+#     role_arn     = "arn:aws:iam::${local.account.shared_account_id}:role/${var.shared_role}"
+#     session_name = "lpa-store-terraform-session"
+#   }
 
-  default_tags {
-    tags = local.default_tags
-  }
-}
+#   default_tags {
+#     tags = local.default_tags
+#   }
+# }

--- a/terraform/account/variables.tf
+++ b/terraform/account/variables.tf
@@ -45,8 +45,8 @@ variable "management_role" {
   default     = "lpa-store-management-ci"
 }
 
-variable "shared_role" {
-  description = "Role to assume in Shared Services account"
-  type        = string
-  default     = "lpa-store-shared-development-ci"
-}
+# variable "shared_role" {
+#   description = "Role to assume in Shared Services account"
+#   type        = string
+#   default     = "lpa-store-shared-development-ci"
+# }


### PR DESCRIPTION
# Purpose

OPG Metrics is decommissioned.

## Approach

- Remove scheduled trigger for key rotation workflow

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service
