### PR TITLE
Don't build opg metrics resources

### DIFF
--- a/terraform/environment/data_sources.tf
+++ b/terraform/environment/data_sources.tf
@@ -2,9 +2,9 @@ data "aws_caller_identity" "current" {
   provider = aws.eu_west_1
 }
 
-data "aws_region" "current" {
-  provider = aws.eu_west_1
-}
+# data "aws_region" "current" {
+#   provider = aws.eu_west_1
+# }
 
 data "aws_default_tags" "current" {
   provider = aws.eu_west_1

--- a/terraform/environment/metric_events.tf
+++ b/terraform/environment/metric_events.tf
@@ -18,7 +18,7 @@
 # }
 
 # resource "aws_iam_role_policy" "opg_metrics" {
-#   name     = "opg-metrics-${data.aws_region.current.name}"
+#   name     = "opg-metrics-${data.aws_region.current.region}"
 #   role     = aws_iam_role.opg_metrics.name
 #   policy   = data.aws_iam_policy_document.opg_metrics.json
 #   provider = aws.eu_west_1

--- a/terraform/environment/metric_events.tf
+++ b/terraform/environment/metric_events.tf
@@ -1,53 +1,53 @@
-resource "aws_cloudwatch_event_rule" "metric_events" {
-  name           = "${data.aws_default_tags.current.tags.environment-name}-metric-events"
-  description    = "forward events to opg-metrics service"
-  event_bus_name = aws_cloudwatch_event_bus.main.name
+# resource "aws_cloudwatch_event_rule" "metric_events" {
+#   name           = "${data.aws_default_tags.current.tags.environment-name}-metric-events"
+#   description    = "forward events to opg-metrics service"
+#   event_bus_name = aws_cloudwatch_event_bus.main.name
 
-  event_pattern = jsonencode({
-    source      = ["opg.poas.lpastore"]
-    detail-type = ["metric"]
-  })
-  provider = aws.eu_west_1
+#   event_pattern = jsonencode({
+#     source      = ["opg.poas.lpastore"]
+#     detail-type = ["metric"]
+#   })
+#   provider = aws.eu_west_1
 
-  state = "DISABLED"
-}
+#   state = "DISABLED"
+# }
 
-data "aws_ssm_parameter" "opg_metrics_arn" {
-  name     = "opg-metrics-api-destination-arn"
-  provider = aws.eu_west_1
-}
+# data "aws_ssm_parameter" "opg_metrics_arn" {
+#   name     = "opg-metrics-api-destination-arn"
+#   provider = aws.eu_west_1
+# }
 
-resource "aws_iam_role_policy" "opg_metrics" {
-  name     = "opg-metrics-${data.aws_region.current.name}"
-  role     = aws_iam_role.opg_metrics.name
-  policy   = data.aws_iam_policy_document.opg_metrics.json
-  provider = aws.eu_west_1
-}
+# resource "aws_iam_role_policy" "opg_metrics" {
+#   name     = "opg-metrics-${data.aws_region.current.name}"
+#   role     = aws_iam_role.opg_metrics.name
+#   policy   = data.aws_iam_policy_document.opg_metrics.json
+#   provider = aws.eu_west_1
+# }
 
 
-data "aws_iam_policy_document" "opg_metrics" {
-  statement {
-    effect  = "Allow"
-    actions = ["events:InvokeApiDestination"]
-    resources = [
-      "${data.aws_ssm_parameter.opg_metrics_arn.value}*"
-    ]
-  }
-  provider = aws.global
-}
+# data "aws_iam_policy_document" "opg_metrics" {
+#   statement {
+#     effect  = "Allow"
+#     actions = ["events:InvokeApiDestination"]
+#     resources = [
+#       "${data.aws_ssm_parameter.opg_metrics_arn.value}*"
+#     ]
+#   }
+#   provider = aws.global
+# }
 
-resource "aws_cloudwatch_event_target" "opg_metrics" {
-  arn            = data.aws_ssm_parameter.opg_metrics_arn.insecure_value
-  event_bus_name = aws_cloudwatch_event_bus.main.name
-  rule           = aws_cloudwatch_event_rule.metric_events.name
-  role_arn       = aws_iam_role.opg_metrics.arn
-  http_target {
-    header_parameters = {
-      Content-Type = "application/json"
-    }
-    path_parameter_values   = []
-    query_string_parameters = {}
-  }
-  input_path = "$.detail"
-  provider   = aws.eu_west_1
-}
+# resource "aws_cloudwatch_event_target" "opg_metrics" {
+#   arn            = data.aws_ssm_parameter.opg_metrics_arn.insecure_value
+#   event_bus_name = aws_cloudwatch_event_bus.main.name
+#   rule           = aws_cloudwatch_event_rule.metric_events.name
+#   role_arn       = aws_iam_role.opg_metrics.arn
+#   http_target {
+#     header_parameters = {
+#       Content-Type = "application/json"
+#     }
+#     path_parameter_values   = []
+#     query_string_parameters = {}
+#   }
+#   input_path = "$.detail"
+#   provider   = aws.eu_west_1
+# }

--- a/terraform/environment/region/apigateway.tf
+++ b/terraform/environment/region/apigateway.tf
@@ -108,7 +108,7 @@ resource "aws_api_gateway_account" "api_gateway" {
 
 
 data "aws_iam_policy_document" "lpa_store" {
-  policy_id = "lpa-store-${var.environment_name}-${data.aws_region.current.name}-resource-policy"
+  policy_id = "lpa-store-${var.environment_name}-${data.aws_region.current.region}-resource-policy"
   override_policy_documents = concat(
     length(var.environment.allowed_wildcard_arns) > 0 ? [data.aws_iam_policy_document.lpa_store_wildcard.json] : [],
     local.ip_restrictions_enabled ? [data.aws_iam_policy_document.lpa_rest_api_ip_restriction_policy[0].json] : []
@@ -136,12 +136,12 @@ data "aws_iam_policy_document" "lpa_store" {
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${var.environment.account_id}:*/current/GET/health-check"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.region}:${var.environment.account_id}:*/current/GET/health-check"]
   }
 }
 
 data "aws_iam_policy_document" "lpa_store_wildcard" {
-  policy_id = "lpa-store-${var.environment_name}-${data.aws_region.current.name}-wildcard-resource-policy"
+  policy_id = "lpa-store-${var.environment_name}-${data.aws_region.current.region}-wildcard-resource-policy"
 
   statement {
     sid    = "AllowExecutionFromWildcards"

--- a/terraform/environment/region/dns.tf
+++ b/terraform/environment/region/dns.tf
@@ -17,7 +17,7 @@ resource "aws_route53_record" "environment_record" {
   name           = local.a_record
   type           = "A"
   zone_id        = data.aws_route53_zone.service.id
-  set_identifier = data.aws_region.current.name
+  set_identifier = data.aws_region.current.region
 
   weighted_routing_policy {
     weight = var.dns_weighting

--- a/terraform/environment/region/iam.tf
+++ b/terraform/environment/region/iam.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "lambda_s3_policy" {
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"
-      values   = ["s3.${data.aws_region.current.name}.amazonaws.com"]
+      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
     }
 
     condition {
@@ -118,4 +118,3 @@ data "aws_iam_policy_document" "lambda_secrets_policy" {
     ]
   }
 }
-

--- a/terraform/environment/region/kms.tf
+++ b/terraform/environment/region/kms.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_key" "cloudwatch" {
-  description             = "CloudWatch ${terraform.workspace} ${data.aws_region.current.name}"
+  description             = "CloudWatch ${terraform.workspace} ${data.aws_region.current.region}"
   deletion_window_in_days = 10
   policy                  = data.aws_iam_policy_document.cloudwatch_kms.json
   enable_key_rotation     = true
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "cloudwatch_kms" {
     ]
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
     }
   }
   statement {

--- a/terraform/modules/fixtures_service/dns.tf
+++ b/terraform/modules/fixtures_service/dns.tf
@@ -12,7 +12,7 @@ resource "aws_route53_record" "fixtures" {
   zone_id        = data.aws_route53_zone.service.zone_id
   name           = "fixtures-${var.environment_name}"
   type           = "A"
-  set_identifier = data.aws_region.current.name
+  set_identifier = data.aws_region.current.region
 
   weighted_routing_policy {
     weight = 100

--- a/terraform/modules/fixtures_service/ecs.tf
+++ b/terraform/modules/fixtures_service/ecs.tf
@@ -70,7 +70,7 @@ locals {
         logDriver = "awslogs",
         options = {
           awslogs-group         = aws_cloudwatch_log_group.fixtures.name,
-          awslogs-region        = data.aws_region.current.name,
+          awslogs-region        = data.aws_region.current.region,
           awslogs-stream-prefix = var.environment_name
         }
       },

--- a/terraform/modules/fixtures_service/iam.tf
+++ b/terraform/modules/fixtures_service/iam.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "ecs_task_role_assume_policy" {
 }
 
 resource "aws_iam_role_policy" "task_role" {
-  name   = "fixtures-task-role-${var.environment_name}-${data.aws_region.current.name}"
+  name   = "fixtures-task-role-${var.environment_name}-${data.aws_region.current.region}"
   role   = aws_iam_role.task_role.id
   policy = data.aws_iam_policy_document.task_role.json
 
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "task_role" {
       "execute-api:Invoke",
       "execute-api:ManageConnections"
     ]
-    resources = ["arn:aws:execute-api:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:aws:execute-api:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
   }
 
   provider = aws.region
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "execution_assume_role" {
 }
 
 resource "aws_iam_role_policy" "execution_role" {
-  name   = "fixtures-execution-role-${var.environment_name}-${data.aws_region.current.name}"
+  name   = "fixtures-execution-role-${var.environment_name}-${data.aws_region.current.region}"
   role   = aws_iam_role.execution_role.id
   policy = data.aws_iam_policy_document.execution_role.json
 

--- a/terraform/modules/fixtures_service/security_group.tf
+++ b/terraform/modules/fixtures_service/security_group.tf
@@ -30,7 +30,7 @@ resource "aws_security_group_rule" "ecs_to_vpc_endpoint" {
 
 data "aws_security_group" "vpc_endpoints_application" {
   vpc_id = var.vpc_id
-  name   = "vpc-endpoint-access-application-subnets-${data.aws_region.current.name}"
+  name   = "vpc-endpoint-access-application-subnets-${data.aws_region.current.region}"
 
   provider = aws.region
 }
@@ -59,7 +59,7 @@ resource "aws_security_group_rule" "ecs_to_vpc_gateways" {
 }
 
 data "aws_prefix_list" "s3" {
-  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   provider = aws.region
 }

--- a/terraform/modules/lambda/iam.tf
+++ b/terraform/modules/lambda/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "lambda" {
-  name = "lambda-${var.lambda_name}-${var.environment_name}-${data.aws_region.current.name}"
+  name = "lambda-${var.lambda_name}-${var.environment_name}-${data.aws_region.current.region}"
   # this path will be used to grant permission to the lambda to access the KMS key
   path               = "/lpa-store-lambda/"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume.json

--- a/terraform/modules/lambda/security_group.tf
+++ b/terraform/modules/lambda/security_group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group_rule" "lambda_to_vpc_endpoint" {
 
 data "aws_security_group" "vpc_endpoints_application" {
   vpc_id = var.vpc_id
-  name   = "vpc-endpoint-access-application-subnets-${data.aws_region.current.name}"
+  name   = "vpc-endpoint-access-application-subnets-${data.aws_region.current.region}"
 }
 
 resource "aws_security_group_rule" "lambda_to_vpc_gateways" {
@@ -27,9 +27,9 @@ resource "aws_security_group_rule" "lambda_to_vpc_gateways" {
 }
 
 data "aws_prefix_list" "dynamodb" {
-  name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  name = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
 }
 
 data "aws_prefix_list" "s3" {
-  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }

--- a/terraform/modules/s3_cross_account_backup/variables.tf
+++ b/terraform/modules/s3_cross_account_backup/variables.tf
@@ -1,5 +1,5 @@
 locals {
-  s3_logging_bucket_name = "${var.s3_access_logging_bucket_prefix}-${data.aws_region.backup_account.name}"
+  s3_logging_bucket_name = "${var.s3_access_logging_bucket_prefix}-${data.aws_region.backup_account.region}"
 }
 
 variable "bucket_name" {


### PR DESCRIPTION
# Purpose

OPG Metrics is decommissioned.

Fixes (Ticket Reference)

## Approach

- comment out opg metrics resources in env configuration

## Learning

Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered about the service
